### PR TITLE
Add libTrace.a symlink for cocoapods

### DIFF
--- a/Trace.xcodeproj/project.pbxproj
+++ b/Trace.xcodeproj/project.pbxproj
@@ -3011,7 +3011,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SDKVERSION=$(xcodebuild -showBuildSettings | grep \"CURRENT_PROJECT_VERSION\" | sed 's/[ ]*CURRENT_PROJECT_VERSION = //')\n\necho \"Creating new folder with new version: ${SDKVERSION}\"\n\ncp -r \"${PROJECT_DIR}/SDK/latest/.\" \"${PROJECT_DIR}/SDK/${SDKVERSION}/\"\n\necho \"Created new folder with new version: ${SDKVERSION}\"\n";
+			shellScript = "SDKVERSION=$(xcodebuild -showBuildSettings | grep \"CURRENT_PROJECT_VERSION\" | sed 's/[ ]*CURRENT_PROJECT_VERSION = //')\n\necho \"Creating new folder with new version: ${SDKVERSION}\"\n\ncp -r \"${PROJECT_DIR}/SDK/latest/.\" \"${PROJECT_DIR}/SDK/${SDKVERSION}/\"\n\nln -s \"${PROJECT_DIR}/SDK/latest/libTrace.a\" \"${PROJECT_DIR}\"\n\necho \"Created new folder with new version: ${SDKVERSION}\"\n";
 		};
 		10A9C80B23E881BA00DCBF4F /* 3. Copy universal static library to SDK folder */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/iOSDemo/Application/AppDelegate.swift
+++ b/iOSDemo/Application/AppDelegate.swift
@@ -8,14 +8,9 @@
 
 import UIKit
 
-#if DEBUG
-// Should be addressed at somepoint:
 // See more here: https://bugs.swift.org/browse/SR-3801
 // and here: https://github.com/apple/swift/commit/08af6f0c0933dc70cb868633e2e017b63c12eba1
-@testable import Trace
-#else
 import Trace
-#endif
 
 @UIApplicationMain
 final class AppDelegate: UIResponder {
@@ -29,7 +24,7 @@ final class AppDelegate: UIResponder {
     
     func setup() {
         timer = .scheduledTimer(withTimeInterval: 3.0, repeats: true, block: { _ in
-            // nothing fancy used for running random tests
+            // nothing fancy only used for running random tests
         })
     }
 }

--- a/libTrace.a
+++ b/libTrace.a
@@ -1,0 +1,1 @@
+SDK/latest/libTrace.a


### PR DESCRIPTION
## Proposed changes:
- Add SDK symlink to the root of the repo. This should help with cocoapods integration if they are pointing to the repo and using a different branch 

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
