### PR TITLE
Fix missing data on first metric request

### DIFF
--- a/Tests/LifecycleTests.swift
+++ b/Tests/LifecycleTests.swift
@@ -28,17 +28,42 @@ final class LifecycleTests: XCTestCase {
     
     // MARK: - Tests
     
-    func testSendNotification() {
+    func testSendNotification_passes() {
         var result = false
         
         Trace.shared.queue.observation = { _ in result = true }
         
         [
             UIApplication.didFinishLaunchingNotification,
-            UIApplication.willEnterForegroundNotification,
             UIApplication.didEnterBackgroundNotification,
+            UIApplication.willEnterForegroundNotification,
             UIApplication.willTerminateNotification,
             UIApplication.didReceiveMemoryWarningNotification
+        ].forEach { NotificationCenter.default.post(Notification(name: $0)) }
+        
+        XCTAssertTrue(result)
+    }
+    
+    func testSendNotification_foreground_observationDoesNotGetTriggered() {
+        var result = false
+        
+        Trace.shared.queue.observation = { _ in result = true }
+        
+        [UIApplication.didFinishLaunchingNotification].forEach {
+            NotificationCenter.default.post(Notification(name: $0))
+        }
+        
+        XCTAssertFalse(result)
+    }
+    
+    func testSendNotification_foreground_observationDoesGetTriggered() {
+        var result = false
+        
+        Trace.shared.queue.observation = { _ in result = true }
+        
+        [
+            UIApplication.didEnterBackgroundNotification,
+            UIApplication.willEnterForegroundNotification
         ].forEach { NotificationCenter.default.post(Notification(name: $0)) }
         
         XCTAssertTrue(result)

--- a/Trace.xcodeproj/project.pbxproj
+++ b/Trace.xcodeproj/project.pbxproj
@@ -2916,7 +2916,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/xcrun --sdk macosx swift";
-			shellScript = "\n";
+			shellScript = "
+";
 		};
 		10512F4724806DC000A3B180 /* Tests - Run Swift via code */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2952,7 +2953,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/xcrun --sdk macosx swift $(SRCROOT)/UploadDSYM/main.swift";
-			shellScript = "\n";
+			shellScript = "
+";
 		};
 		1053AAC4240543A600F90393 /* Run Pecker linter tool - Disabled */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3007,7 +3009,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/xcrun --sdk macosx swift $(SRCROOT)/UploadDSYM/main.swift";
-			shellScript = "\n";
+			shellScript = "
+";
 		};
 		10A9C80A23E8809B00DCBF4F /* 5. Create folder with new version */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Trace.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Trace.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Trace/Hardware/Device/DeviceFormatter.swift
+++ b/Trace/Hardware/Device/DeviceFormatter.swift
@@ -134,7 +134,7 @@ internal struct DeviceFormatter: JSONEncodable {
                     .compactMap { $0 }
                     .joined()
                 
-                if !names.isEmpty {
+                if !names.isEmpty, names != "Carrier" {
                     details[Keys.Carrier.name.rawValue] = names
                 }
                 
@@ -143,7 +143,7 @@ internal struct DeviceFormatter: JSONEncodable {
                 }
             }
         } else if let carrier = networkInfo.subscriberCellularProvider {
-            if let name = carrier.carrierName, !name.isEmpty {
+            if let name = carrier.carrierName, !name.isEmpty, name != "Carrier" {
                 details[Keys.Carrier.name.rawValue] = name
             }
             

--- a/Trace/Hardware/Session.swift
+++ b/Trace/Hardware/Session.swift
@@ -18,8 +18,6 @@ final class Session {
     
     var resource: Resource? {
         didSet {
-            Logger.print(.application, "Resource created for this session")
-            
             resource?.session = uuid.string
             
             if let resources = try? resource?.dictionary() {
@@ -29,6 +27,8 @@ final class Session {
             
             if let oldValue = oldValue {
                 resource?.network = oldValue.network
+            } else {
+                Logger.print(.application, "Resource created for this session")
             }
         }
     }
@@ -42,7 +42,7 @@ final class Session {
     // MARK: - Init
     
     // Update the session every 15 seconds
-    internal init(timeout: Double = 15.0, delay: Double = 0.25) {
+    internal init(timeout: Double = 15.0, delay: Double = 0.05) {
         self.repeater = Repeater(timeout)
         self.delay = delay
         self.uuid = ULID()

--- a/Trace/Queue/Queue.swift
+++ b/Trace/Queue/Queue.swift
@@ -138,6 +138,17 @@ internal final class Queue {
                 Logger.print(.queue, "Scheduling \(combined.count) traces")
                 
                 combined.forEach { trace in
+                    // fallback
+                    if trace.resource == nil {
+                        Logger.print(.internalError, "Resource missing from new trace model")
+                        
+                        if let newResource = self?.session.resource {
+                            Logger.print(.internalError, "Injecting last known Resource into trace model")
+                            
+                            trace.resource = newResource
+                        }
+                    }
+                    
                     self?.scheduler.schedule(trace, {
                         switch $0 {
                         case .success:

--- a/Trace/Trace.swift
+++ b/Trace/Trace.swift
@@ -52,9 +52,9 @@ final public class Trace: NSObject {
     // MARK: - Init
     
     private override init() {
+        session = Session()
         network = Network()
         database = Database()
-        session = Session()
         
         scheduler = Scheduler(with: network)
         queue = Queue(with: scheduler, database, session) // make sure queue startup first


### PR DESCRIPTION
## Proposed changes:
- Moved session class as the first object to start
- Add resource if it's missing from trace model
- Made sure to add validation before calling `did come back to foreground`
- Reduced resource creation delay 
- Adjusted logs
- Check if `Carrier` is passed
- More tests

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
