### PR TITLE
Span validator to log incase SDK sends wrong timespan

### DIFF
--- a/Tests/TraceModelTests.swift
+++ b/Tests/TraceModelTests.swift
@@ -337,4 +337,55 @@ final class TraceModelTests: XCTestCase {
         XCTAssertEqual(model.spans.count, 5002)
         XCTAssertTrue(model.isComplete)
     }
+    
+    func testTraceSpan_valid() {
+        let attribute = TraceModel.Span.Attributes(attributes: [
+            TraceModel.Span.Attributes.Attribute(name: "br_test1", value: TraceModel.Span.Name(value: "test", truncatedByteCount: 0))
+        ])
+        let traceId = "1234"
+        let span = TraceModel.Span(
+            traceId: traceId,
+            spanId: "1234",
+            name: TraceModel.Span.Name(value: "test", truncatedByteCount: 0),
+            start: TraceModel.Span.Timestamp(seconds: 100, nanos: 001),
+            end: TraceModel.Span.Timestamp(seconds: 200, nanos: 002),
+            attribute: attribute
+        )
+        
+        XCTAssert(span.spanValidator(span: span))
+    }
+    
+    func testTraceSpan_invalidBySeconds() {
+        let attribute = TraceModel.Span.Attributes(attributes: [
+            TraceModel.Span.Attributes.Attribute(name: "br_test1", value: TraceModel.Span.Name(value: "test", truncatedByteCount: 0))
+        ])
+        let traceId = "1234"
+        let span = TraceModel.Span(
+            traceId: traceId,
+            spanId: "1234",
+            name: TraceModel.Span.Name(value: "test", truncatedByteCount: 0),
+            start: TraceModel.Span.Timestamp(seconds: 300, nanos: 001),
+            end: TraceModel.Span.Timestamp(seconds: 200, nanos: 002),
+            attribute: attribute
+        )
+        
+        XCTAssertFalse(span.spanValidator(span: span))
+    }
+    
+    func testTraceSpan_invalidByNanos() {
+        let attribute = TraceModel.Span.Attributes(attributes: [
+            TraceModel.Span.Attributes.Attribute(name: "br_test1", value: TraceModel.Span.Name(value: "test", truncatedByteCount: 0))
+        ])
+        let traceId = "1234"
+        let span = TraceModel.Span(
+            traceId: traceId,
+            spanId: "1234",
+            name: TraceModel.Span.Name(value: "test", truncatedByteCount: 0),
+            start: TraceModel.Span.Timestamp(seconds: 200, nanos: 001),
+            end: TraceModel.Span.Timestamp(seconds: 200, nanos: 000),
+            attribute: attribute
+        )
+        
+        XCTAssertFalse(span.spanValidator(span: span))
+    }
 }

--- a/Tests/TraceModelTests.swift
+++ b/Tests/TraceModelTests.swift
@@ -388,4 +388,38 @@ final class TraceModelTests: XCTestCase {
         
         XCTAssertFalse(span.validate())
     }
+    
+    func testTraceSpan_invalidBySameTime() {
+        let attribute = TraceModel.Span.Attributes(attributes: [
+            TraceModel.Span.Attributes.Attribute(name: "br_test1", value: TraceModel.Span.Name(value: "test", truncatedByteCount: 0))
+        ])
+        let traceId = "1234"
+        let span = TraceModel.Span(
+            traceId: traceId,
+            spanId: "1234",
+            name: TraceModel.Span.Name(value: "test", truncatedByteCount: 0),
+            start: TraceModel.Span.Timestamp(seconds: 200, nanos: 001),
+            end: TraceModel.Span.Timestamp(seconds: 200, nanos: 001),
+            attribute: attribute
+        )
+        
+        XCTAssertFalse(span.validate())
+    }
+    
+    func testTraceSpan_invalidByNoEndTime() {
+        let attribute = TraceModel.Span.Attributes(attributes: [
+            TraceModel.Span.Attributes.Attribute(name: "br_test1", value: TraceModel.Span.Name(value: "test", truncatedByteCount: 0))
+        ])
+        let traceId = "1234"
+        let span = TraceModel.Span(
+            traceId: traceId,
+            spanId: "1234",
+            name: TraceModel.Span.Name(value: "test", truncatedByteCount: 0),
+            start: TraceModel.Span.Timestamp(seconds: 200, nanos: 001),
+            end: nil,
+            attribute: attribute
+        )
+        
+        XCTAssertFalse(span.validate())
+    }
 }

--- a/Tests/TraceModelTests.swift
+++ b/Tests/TraceModelTests.swift
@@ -352,7 +352,7 @@ final class TraceModelTests: XCTestCase {
             attribute: attribute
         )
         
-        XCTAssert(span.spanValidator(span: span))
+        XCTAssert(span.validate())
     }
     
     func testTraceSpan_invalidBySeconds() {
@@ -369,7 +369,7 @@ final class TraceModelTests: XCTestCase {
             attribute: attribute
         )
         
-        XCTAssertFalse(span.spanValidator(span: span))
+        XCTAssertFalse(span.validate())
     }
     
     func testTraceSpan_invalidByNanos() {
@@ -386,6 +386,6 @@ final class TraceModelTests: XCTestCase {
             attribute: attribute
         )
         
-        XCTAssertFalse(span.spanValidator(span: span))
+        XCTAssertFalse(span.validate())
     }
 }

--- a/Trace/TraceModel/TraceModel+Span.swift
+++ b/Trace/TraceModel/TraceModel+Span.swift
@@ -285,7 +285,7 @@ extension TraceModel {
             
             #if Debug
             // TODO: only for private beta testing. remove before GA
-            spanValidator(span: self)
+            validate()
             #endif
         }
         
@@ -311,21 +311,20 @@ extension TraceModel {
         
         /// :nodoc:
         @discardableResult
-        public func spanValidator(span: Span) -> Bool {
-            guard let strongEnd = span.end else {
-                return true
+        internal func validate() -> Bool {
+            guard let strongEnd = end else {
+                return false
             }
             
             var valid = true
-            if span.start.seconds > strongEnd.seconds {
+            if start.seconds > strongEnd.seconds {
                 valid = false
-            } else if span.start.seconds == strongEnd.seconds {
-                if span.start.nanos > strongEnd.nanos {
+            } else if start.seconds == strongEnd.seconds {
+                if start.nanos > strongEnd.nanos {
                     valid = false
                 }
             }
             
-            //GA info
             if !valid {
                 Logger.print(.internalError, "Span end timestamp is before it's start timestamp!")
             }

--- a/Trace/TraceModel/TraceModel+Span.swift
+++ b/Trace/TraceModel/TraceModel+Span.swift
@@ -320,7 +320,7 @@ extension TraceModel {
             if start.seconds > strongEnd.seconds {
                 valid = false
             } else if start.seconds == strongEnd.seconds {
-                if start.nanos > strongEnd.nanos || start.nanos == strongEnd.nanos {
+                if start.nanos >= strongEnd.nanos {
                     valid = false
                 }
             }

--- a/Trace/TraceModel/TraceModel+Span.swift
+++ b/Trace/TraceModel/TraceModel+Span.swift
@@ -320,7 +320,7 @@ extension TraceModel {
             if start.seconds > strongEnd.seconds {
                 valid = false
             } else if start.seconds == strongEnd.seconds {
-                if start.nanos > strongEnd.nanos {
+                if start.nanos > strongEnd.nanos || start.nanos == strongEnd.nanos {
                     valid = false
                 }
             }

--- a/Trace/TraceModel/TraceModel+Span.swift
+++ b/Trace/TraceModel/TraceModel+Span.swift
@@ -63,10 +63,10 @@ extension TraceModel {
             
             private func setup() {
                 #if Debug
-                    // TODO: only for private beta testing. remove before GA
-                    if !TimestampValidator(toDate: Date()).isValid(seconds: seconds, nanos: nanos) {
-                        Logger.print(.internalError, "Timestamp \(seconds).\(nanos) is invalid")
-                    }
+                // TODO: only for private beta testing. remove before GA
+                if !TimestampValidator(toDate: Date()).isValid(seconds: seconds, nanos: nanos) {
+                    Logger.print(.internalError, "Timestamp \(seconds).\(nanos) is invalid")
+                }
                 #endif
             }
         }
@@ -258,7 +258,7 @@ extension TraceModel {
                     debugDescription: "")
                 )
             }
-        
+            
             spanId = span
             parentSpanId = try container.decode(String?.self, forKey: .parentSpanId)?.fromHex
             name = try container.decode(Name.self, forKey: .name)
@@ -284,8 +284,8 @@ extension TraceModel {
             try container.encode(attribute, forKey: .attributes)
             
             #if Debug
-                // TODO: only for private beta testing. remove before GA
-                spanValidator(start: start, end: end)
+            // TODO: only for private beta testing. remove before GA
+            spanValidator(span: self)
             #endif
         }
         
@@ -306,32 +306,32 @@ extension TraceModel {
             
             return copy
         }
-
+        
         // MARK: - Span validator
         
         /// :nodoc:
         @discardableResult
-        private func spanValidator(start: Timestamp, end: Timestamp?) -> Bool {
-             guard let strongEnd = end else {
-                 return true
-             }
-             
-             var valid = true
-             if start.seconds > strongEnd.seconds {
-                 valid = false
-             } else if start.seconds == strongEnd.seconds {
-                 if start.nanos > strongEnd.nanos {
-                     valid = false
-                 }
-             }
-             
+        public func spanValidator(span: Span) -> Bool {
+            guard let strongEnd = span.end else {
+                return true
+            }
+            
+            var valid = true
+            if span.start.seconds > strongEnd.seconds {
+                valid = false
+            } else if span.start.seconds == strongEnd.seconds {
+                if span.start.nanos > strongEnd.nanos {
+                    valid = false
+                }
+            }
+            
             //GA info
-             if !valid {
-                 Logger.print(.internalError, "Span end timestamp is before it's start timestamp!")
-             }
-             
-             return valid
-         }
+            if !valid {
+                Logger.print(.internalError, "Span end timestamp is before it's start timestamp!")
+            }
+            
+            return valid
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes:
- Added a span validator which is called during encode process.
- Added test to check the validator.

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
