### PR TITLE
Don't get carrier info if running on a simulator

### DIFF
--- a/Trace/Hardware/Device/DeviceFormatter.swift
+++ b/Trace/Hardware/Device/DeviceFormatter.swift
@@ -117,7 +117,7 @@ internal struct DeviceFormatter: JSONEncodable {
         details[Keys.Disk.freeDiskSpace.rawValue] = fileManager.freeDiskSpace
         details[Keys.Disk.usedDiskSpace.rawValue] = fileManager.usedDiskSpace
         
-        #if !targetEnvironment(macCatalyst)
+        #if !targetEnvironment(macCatalyst) && !targetEnvironment(simulator)
         let networkInfo = CTTelephonyNetworkInfo()
         
         if #available(iOS 12.0, *) {


### PR DESCRIPTION
## Proposed changes:
- Fetching network carrier info results on a simulator results in error messages.
- Added a condition to prevent that.

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
