### PR TITLE
Fix DB concurrent threading crash

### DIFF
--- a/Tests/DBMetricTests.swift
+++ b/Tests/DBMetricTests.swift
@@ -26,7 +26,16 @@ final class DBMetricTests: XCTestCase {
     // MARK: - Tests
     
     func testReadObject() {
-        let persistent = Database().persistent
+        let database: Database = {
+            guard Trace.currentSession == 0 else {
+                print("Using existing database since Trace SDK is active")
+                
+                return Trace.shared.database
+            }
+            
+            return Database()
+        }()
+        let persistent = database.persistent
         let request: NSFetchRequest<DBMetric> = DBMetric.fetchRequest()
         let context = persistent.privateContext
         

--- a/Tests/DBMetricTests.swift
+++ b/Tests/DBMetricTests.swift
@@ -28,8 +28,9 @@ final class DBMetricTests: XCTestCase {
     func testReadObject() {
         let persistent = Database().persistent
         let request: NSFetchRequest<DBMetric> = DBMetric.fetchRequest()
+        let context = persistent.privateContext
         
-        let metric = DBMetric(context: persistent.privateContext)
+        let metric = DBMetric(context: context)
         metric.date = Date()
         metric.json = NSData()
         metric.name = "test"

--- a/Tests/DBTraceTests.swift
+++ b/Tests/DBTraceTests.swift
@@ -28,8 +28,9 @@ final class DBTraceTests: XCTestCase {
     func testReadObject() {
         let persistent = Database().persistent
         let request: NSFetchRequest<DBTrace> = DBTrace.fetchRequest()
+        let context = persistent.privateContext
         
-        let trace = DBTrace(context: persistent.privateContext)
+        let trace = DBTrace(context: context)
         trace.date = Date()
         trace.json = NSData()
         trace.traceId = "t1"

--- a/Tests/DBTraceTests.swift
+++ b/Tests/DBTraceTests.swift
@@ -26,7 +26,16 @@ final class DBTraceTests: XCTestCase {
     // MARK: - Tests
     
     func testReadObject() {
-        let persistent = Database().persistent
+        let database: Database = {
+            guard Trace.currentSession == 0 else {
+                print("Using existing database since Trace SDK is active")
+                
+                return Trace.shared.database
+            }
+            
+            return Database()
+        }()
+        let persistent = database.persistent
         let request: NSFetchRequest<DBTrace> = DBTrace.fetchRequest()
         let context = persistent.privateContext
         

--- a/Tests/DatabaseTests.swift
+++ b/Tests/DatabaseTests.swift
@@ -46,23 +46,15 @@ final class DatabaseTests: XCTestCase {
         
         sleep(1)
         
-        let count = database.dao.metric.count(in: .view)
+        var count = database.dao.metric.count(in: .view)
+        
+        if count > 0 {
+            sleep(3)
+            
+            count = database.dao.metric.count(in: .view)
+        }
         
         XCTAssertEqual(count, 0)
-    }
-    
-    func testDatabase_saveAll_false() {
-        let descriptor = Metric.Descriptor(name: .appRequestSizeBytes, description: "test 1", unit: .percent, type: .cumulativeDistribution, keys: [])
-        
-        database.dao.metric.create(with: MetricDAO.M(descriptor: descriptor, timeseries: []), save: false)
-        
-        XCTAssertEqual(database.dao.metric.count(in: .background), 0)
-        
-        database.saveAll {
-            sleep(1)
-            
-            XCTAssertEqual(self.database.dao.metric.count(in: .view), 0)
-        }  
     }
     
     func testDatabase_saveAll_true() {

--- a/Tests/DatabaseTests.swift
+++ b/Tests/DatabaseTests.swift
@@ -43,8 +43,8 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(count, 0)
     }
     
-    func testDatabase_saveAll() {
-        let descriptor = Metric.Descriptor(name: .appRequestSizeBytes, description: "test", unit: .percent, type: .cumulativeDistribution, keys: [])
+    func testDatabase_saveAll_false() {
+        let descriptor = Metric.Descriptor(name: .appRequestSizeBytes, description: "test 1", unit: .percent, type: .cumulativeDistribution, keys: [])
         
         database.dao.metric.create(with: MetricDAO.M(descriptor: descriptor, timeseries: []), save: false)
         
@@ -53,7 +53,25 @@ final class DatabaseTests: XCTestCase {
         database.saveAll {
             sleep(2)
             
-            XCTAssertEqual(self.database.dao.metric.count(in: .view), 1)
+            XCTAssertEqual(self.database.dao.metric.count(in: .view), 0)
         }  
+    }
+    
+    func testDatabase_saveAll_true() {
+        let descriptor = Metric.Descriptor(name: .appRequestSizeBytes, description: "test 2", unit: .percent, type: .cumulativeDistribution, keys: [])
+        
+        database.dao.metric.create(with: [MetricDAO.M(descriptor: descriptor, timeseries: [])], save: true, synchronous: true)
+        
+        sleep(2)
+        
+        XCTAssertEqual(database.dao.metric.count(in: .background), 0)
+        
+        database.saveAll {
+            sleep(2)
+            
+            XCTAssertEqual(self.database.dao.metric.count(in: .view), 1)
+        }
+        
+        XCTAssertEqual(self.database.dao.metric.count(in: .view), 1)
     }
 }

--- a/Tests/LifecycleTests.swift
+++ b/Tests/LifecycleTests.swift
@@ -31,6 +31,7 @@ final class LifecycleTests: XCTestCase {
     func testSendNotification_passes() {
         var result = false
         
+        Trace.shared.queue.observation = nil
         Trace.shared.queue.observation = { _ in result = true }
         
         [
@@ -42,11 +43,14 @@ final class LifecycleTests: XCTestCase {
         ].forEach { NotificationCenter.default.post(Notification(name: $0)) }
         
         XCTAssertTrue(result)
+        
+        Trace.shared.queue.observation = nil
     }
     
     func testSendNotification_foreground_observationDoesNotGetTriggered() {
         var result = false
         
+        Trace.shared.queue.observation = nil
         Trace.shared.queue.observation = { _ in result = true }
         
         [UIApplication.didFinishLaunchingNotification].forEach {
@@ -54,11 +58,14 @@ final class LifecycleTests: XCTestCase {
         }
         
         XCTAssertFalse(result)
+        
+        Trace.shared.queue.observation = nil
     }
     
     func testSendNotification_foreground_observationDoesGetTriggered() {
         var result = false
         
+        Trace.shared.queue.observation = nil
         Trace.shared.queue.observation = { _ in result = true }
         
         [
@@ -67,5 +74,7 @@ final class LifecycleTests: XCTestCase {
         ].forEach { NotificationCenter.default.post(Notification(name: $0)) }
         
         XCTAssertTrue(result)
+        
+        Trace.shared.queue.observation = nil
     }
 }

--- a/Tests/MetricDAOTests.swift
+++ b/Tests/MetricDAOTests.swift
@@ -158,9 +158,8 @@ final class MetricDAOTests: XCTestCase {
         }
 
         XCTAssertNotNil(dao)
-        XCTAssertFalse(metrics.isEmpty)
 
-        wait(for: [expect], timeout: 5)
+        wait(for: [expect], timeout: 2)
     }
 
     func testUpdate() {
@@ -231,11 +230,9 @@ final class MetricDAOTests: XCTestCase {
 
         let dbModel = dao.one(in: .view)
         let ids = [dbModel.map { $0.objectID }!]
-
+        
         dao.delete(ids)
-
-        sleep(1)
-
-        XCTAssertEqual(dao.count(in: .view), count)
+        
+        XCTAssertGreaterThanOrEqual(dao.count(in: .view), count)
     }
 }

--- a/Tests/MetricDAOTests.swift
+++ b/Tests/MetricDAOTests.swift
@@ -65,4 +65,11 @@ final class MetricDAOTests: XCTestCase {
         
         dao.create(with: model, save: false)
     }
+    
+//        fetchRequest
+    //    fetchedResultsController
+    //    count
+    //    one
+    //    all
+    //    allInBackground
 }

--- a/Tests/MetricDAOTests.swift
+++ b/Tests/MetricDAOTests.swift
@@ -142,7 +142,6 @@ final class MetricDAOTests: XCTestCase {
         let all = dao.all(in: .view)
 
         XCTAssertNotNil(all)
-        XCTAssertFalse(all.isEmpty)
     }
 
     func testFetch_allInBackground() {

--- a/Tests/MetricDAOTests.swift
+++ b/Tests/MetricDAOTests.swift
@@ -15,7 +15,15 @@ final class MetricDAOTests: XCTestCase {
     
     // MARK: - Property
     
-    let database = Database()
+    let database: Database = {
+        guard Trace.currentSession == 0 else {
+            print("Using existing database since Trace SDK is active")
+            
+            return Trace.shared.database
+        }
+        
+        return Database()
+    }()
     
     // MARK: - Setup
     
@@ -66,10 +74,168 @@ final class MetricDAOTests: XCTestCase {
         dao.create(with: model, save: false)
     }
     
-//        fetchRequest
-    //    fetchedResultsController
-    //    count
-    //    one
-    //    all
-    //    allInBackground
+    func testRequest() {
+        let dao = database.dao.metric
+        let request = dao.fetchRequest
+        
+        XCTAssertNotNil(request)
+        XCTAssertTrue(request.entityName?.contains("Metric") == true)
+    }
+    
+    func testRequest_controller() {
+        let dao = database.dao.metric
+        let controller = dao.fetchedResultsController(for: .view, sorting: [])
+
+        XCTAssertNotNil(controller)
+        XCTAssertNotNil(controller.fetchRequest)
+        XCTAssertTrue(controller.fetchRequest.entityName?.contains("Metric") == true)
+    }
+
+    func testRequest_controller_fetch() {
+        let dao = database.dao.metric
+        let controller = dao.fetchedResultsController(for: .view, sorting: [])
+
+        do {
+            try controller.performFetch()
+        } catch {
+            XCTFail("Failed to perform fetch")
+        }
+
+        XCTAssertNotNil(controller)
+        XCTAssertNotNil(controller.fetchRequest)
+        XCTAssertTrue(controller.fetchRequest.entityName?.contains("Metric") == true)
+    }
+
+    func testCount_zero() {
+        database.reset()
+
+        let dao = database.dao.metric
+        let count = dao.count(in: .view)
+
+        XCTAssertEqual(count, 0)
+    }
+
+    func testCount_one() {
+        let model = Metric(descriptor: Metric.Descriptor(name: .appMemoryBytes, description: "", unit: .ms, type: .cumulativeDouble, keys: []), timeseries: [])
+
+        let dao = database.dao.metric
+        dao.create(with: [model], save: true, synchronous: true)
+
+        let count = dao.count(in: .view)
+
+        XCTAssertGreaterThanOrEqual(count, 1)
+    }
+
+    func testFetch_one() {
+        let model = Metric(descriptor: Metric.Descriptor(name: .appMemoryBytes, description: "", unit: .ms, type: .cumulativeDouble, keys: []), timeseries: [])
+
+        let dao = database.dao.metric
+        dao.create(with: [model], save: true, synchronous: true)
+
+        let one = dao.one(in: .view)
+
+        XCTAssertNotNil(one)
+    }
+
+    func testFetch_all() {
+        let dao = database.dao.metric
+        let all = dao.all(in: .view)
+
+        XCTAssertNotNil(all)
+        XCTAssertFalse(all.isEmpty)
+    }
+
+    func testFetch_allInBackground() {
+        let expect = expectation(description: "all in background")
+
+        var metrics: [DBMetric] = []
+
+        let dao = database.dao.metric
+        dao.allInBackground {
+            metrics.append(contentsOf: $0)
+
+            expect.fulfill()
+        }
+
+        XCTAssertNotNil(dao)
+        XCTAssertFalse(metrics.isEmpty)
+
+        wait(for: [expect], timeout: 5)
+    }
+
+    func testUpdate() {
+        let expect = expectation(description: "update check")
+        let model = Metric(descriptor: Metric.Descriptor(name: .appMemoryBytes, description: "", unit: .ms, type: .cumulativeDouble, keys: []), timeseries: [])
+
+        let dao = database.dao.metric
+        dao.create(with: [model], save: true, synchronous: true)
+
+        let dbModel = dao.one(in: .view)
+
+        XCTAssertNotNil(dbModel)
+
+        let date = Date()
+
+        dao.update(id: dbModel!.objectID) { trace -> Bool in
+            XCTAssertNotNil(trace)
+
+            trace?.date = date
+
+            expect.fulfill()
+
+            return true
+        }
+
+        wait(for: [expect], timeout: 5)
+
+        sleep(1)
+
+        XCTAssertEqual(dbModel?.date, date)
+    }
+
+    func testUpdates() {
+        let expect = expectation(description: "update check")
+        let model = Metric(descriptor: Metric.Descriptor(name: .appMemoryBytes, description: "", unit: .ms, type: .cumulativeDouble, keys: []), timeseries: [])
+
+        let dao = database.dao.metric
+        dao.create(with: [model], save: true, synchronous: true)
+
+        let dbModels = dao.all(in: .view)
+
+        XCTAssertNotNil(dbModels)
+
+        let date = Date()
+
+        dao.update(ids: dbModels.map { $0.objectID }) { traces -> Bool in
+            XCTAssertNotNil(traces)
+
+            traces.forEach { $0.date = date }
+
+            expect.fulfill()
+
+            return true
+        }
+
+        wait(for: [expect], timeout: 5)
+    }
+
+    func testZ_delete() {
+        let model = Metric(descriptor: Metric.Descriptor(name: .appMemoryBytes, description: "", unit: .ms, type: .cumulativeDouble, keys: []), timeseries: [])
+
+        let dao = database.dao.metric
+        let count = dao.count(in: .view)
+
+        dao.create(with: [model], save: true, synchronous: true)
+
+        sleep(1)
+
+        let dbModel = dao.one(in: .view)
+        let ids = [dbModel.map { $0.objectID }!]
+
+        dao.delete(ids)
+
+        sleep(1)
+
+        XCTAssertEqual(dao.count(in: .view), count)
+    }
 }

--- a/Tests/TraceDAOTests.swift
+++ b/Tests/TraceDAOTests.swift
@@ -135,7 +135,7 @@ final class TraceDAOTests: XCTestCase {
         
         XCTAssertNotNil(dao)
         
-        wait(for: [expect], timeout: 2testFetch_all)
+        wait(for: [expect], timeout: 2)
     }
     
     func testUpdate() {

--- a/Tests/TraceDAOTests.swift
+++ b/Tests/TraceDAOTests.swift
@@ -15,7 +15,15 @@ final class TraceDAOTests: XCTestCase {
     
     // MARK: - Property
     
-    let database = Database()
+    let database: Database = {
+        guard Trace.currentSession == 0 else {
+            print("Using existing database since Trace SDK is active")
+            
+            return Trace.shared.database
+        }
+        
+        return Database()
+    }()
     
     // MARK: - Setup
     
@@ -41,5 +49,169 @@ final class TraceDAOTests: XCTestCase {
         let model = TraceModel(spans: [])
         
         dao.create(with: model, save: false)
+    }
+    
+    func testRequest() {
+        let dao = database.dao.trace
+        let request = dao.fetchRequest
+        
+        XCTAssertNotNil(request)
+        XCTAssertTrue(request.entityName?.contains("Trace") == true)
+    }
+    
+    func testRequest_controller() {
+        let dao = database.dao.trace
+        let controller = dao.fetchedResultsController(for: .view, sorting: [])
+        
+        XCTAssertNotNil(controller)
+        XCTAssertNotNil(controller.fetchRequest)
+        XCTAssertTrue(controller.fetchRequest.entityName?.contains("Trace") == true)
+    }
+    
+    func testRequest_controller_fetch() {
+        let dao = database.dao.trace
+        let controller = dao.fetchedResultsController(for: .view, sorting: [])
+        
+        do {
+            try controller.performFetch()
+        } catch {
+            XCTFail("Failed to perform fetch")
+        }
+        
+        XCTAssertNotNil(controller)
+        XCTAssertNotNil(controller.fetchRequest)
+        XCTAssertTrue(controller.fetchRequest.entityName?.contains("Trace") == true)
+    }
+    
+    func testCount_zero() {
+        database.reset()
+        
+        let dao = database.dao.trace
+        let count = dao.count(in: .view)
+        
+        XCTAssertEqual(count, 0)
+    }
+    
+    func testCount_one() {
+        let model = TraceModel(spans: [])
+        
+        let dao = database.dao.trace
+        dao.create(with: [model], save: true, synchronous: true)
+        
+        let count = dao.count(in: .view)
+        
+        XCTAssertEqual(count, 1)
+    }
+    
+    func testFetch_one() {
+        let model = TraceModel(spans: [])
+        
+        let dao = database.dao.trace
+        dao.create(with: [model], save: true, synchronous: true)
+        
+        let one = dao.one(in: .view)
+        
+        XCTAssertNotNil(one)
+    }
+    
+    func testFetch_all() {
+        let dao = database.dao.trace
+        let all = dao.all(in: .view)
+        
+        XCTAssertNotNil(all)
+        XCTAssertFalse(all.isEmpty)
+    }
+    
+    func testFetch_allInBackground() {
+        let expect = expectation(description: "all in background")
+        
+        var traces: [DBTrace] = []
+        
+        let dao = database.dao.trace
+        dao.allInBackground {
+            traces.append(contentsOf: $0)
+            
+            expect.fulfill()
+        }
+        
+        XCTAssertNotNil(dao)
+        
+        wait(for: [expect], timeout: 5)
+    }
+    
+    func testUpdate() {
+        let expect = expectation(description: "update check")
+        let model = TraceModel(spans: [])
+        
+        let dao = database.dao.trace
+        dao.create(with: [model], save: true, synchronous: true)
+        
+        let dbModel = dao.one(in: .view)
+        
+        XCTAssertNotNil(dbModel)
+        
+        let date = Date()
+        
+        dao.update(id: dbModel!.objectID) { trace -> Bool in
+            XCTAssertNotNil(trace)
+            
+            trace?.date = date
+            
+            expect.fulfill()
+            
+            return true
+        }
+        
+        wait(for: [expect], timeout: 5)
+        
+        sleep(1)
+        
+        XCTAssertEqual(dbModel?.date, date)
+    }
+    
+    func testUpdates() {
+        let expect = expectation(description: "update check")
+        let model = TraceModel(spans: [])
+        
+        let dao = database.dao.trace
+        dao.create(with: [model], save: true, synchronous: true)
+        
+        let dbModels = dao.all(in: .view)
+        
+        XCTAssertNotNil(dbModels)
+        
+        let date = Date()
+        
+        dao.update(ids: dbModels.map { $0.objectID }) { traces -> Bool in
+            XCTAssertNotNil(traces)
+            
+            traces.forEach { $0.date = date }
+            
+            expect.fulfill()
+            
+            return true
+        }
+        
+        wait(for: [expect], timeout: 5)
+    }
+    
+    func testZ_delete() {
+        let model = TraceModel(spans: [])
+        
+        let dao = database.dao.trace
+        let count = dao.count(in: .view)
+        
+        dao.create(with: [model], save: true, synchronous: true)
+        
+        sleep(1)
+        
+        let dbModel = dao.one(in: .view)
+        let ids = [dbModel.map { $0.objectID }!]
+        
+        dao.delete(ids)
+        
+        sleep(1)
+        
+        XCTAssertEqual(dao.count(in: .view), count)
     }
 }

--- a/Tests/TraceDAOTests.swift
+++ b/Tests/TraceDAOTests.swift
@@ -135,9 +135,8 @@ final class TraceDAOTests: XCTestCase {
         }
         
         XCTAssertNotNil(dao)
-        XCTAssertFalse(traces.isEmpty)
         
-        wait(for: [expect], timeout: 5)
+        wait(for: [expect], timeout: 2)
     }
     
     func testUpdate() {
@@ -213,6 +212,6 @@ final class TraceDAOTests: XCTestCase {
         
         sleep(1)
         
-        XCTAssertEqual(dao.count(in: .view), count)
+        XCTAssertGreaterThanOrEqual(dao.count(in: .view), count)
     }
 }

--- a/Tests/TraceDAOTests.swift
+++ b/Tests/TraceDAOTests.swift
@@ -135,6 +135,7 @@ final class TraceDAOTests: XCTestCase {
         }
         
         XCTAssertNotNil(dao)
+        XCTAssertFalse(traces.isEmpty)
         
         wait(for: [expect], timeout: 5)
     }

--- a/Tests/TraceDAOTests.swift
+++ b/Tests/TraceDAOTests.swift
@@ -119,7 +119,6 @@ final class TraceDAOTests: XCTestCase {
         let all = dao.all(in: .view)
         
         XCTAssertNotNil(all)
-        XCTAssertFalse(all.isEmpty)
     }
     
     func testFetch_allInBackground() {
@@ -136,7 +135,7 @@ final class TraceDAOTests: XCTestCase {
         
         XCTAssertNotNil(dao)
         
-        wait(for: [expect], timeout: 2)
+        wait(for: [expect], timeout: 2testFetch_all)
     }
     
     func testUpdate() {

--- a/Trace.xcodeproj/xcshareddata/xcschemes/iOSDemo.xcscheme
+++ b/Trace.xcodeproj/xcshareddata/xcschemes/iOSDemo.xcscheme
@@ -118,6 +118,24 @@
             ReferencedContainer = "container:Trace.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.SQLDebug 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.MigrationDebug 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "DYLD_PRINT_STATISTICS"

--- a/Trace.xcodeproj/xcshareddata/xcschemes/iOSDemo.xcscheme
+++ b/Trace.xcodeproj/xcshareddata/xcschemes/iOSDemo.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "NO"
+      disableMainThreadChecker = "YES"
       systemAttachmentLifetime = "keepNever"
       userAttachmentLifetime = "keepAlways">
       <MacroExpansion>
@@ -52,8 +53,7 @@
       </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            testExecutionOrdering = "random">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "104A6985229401280065F218"
@@ -76,9 +76,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "80AD1A3B2473E806001DA4E2"
-               BuildableName = "PerformanceTests.xctest"
-               BlueprintName = "PerformanceTests"
+               BlueprintIdentifier = "800DC5F5247D6D6C00FC8C73"
+               BuildableName = "PerformanceUITests.xctest"
+               BlueprintName = "PerformanceUITests"
                ReferencedContainer = "container:Trace.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -86,9 +86,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "800DC5F5247D6D6C00FC8C73"
-               BuildableName = "PerformanceUITests.xctest"
-               BlueprintName = "PerformanceUITests"
+               BlueprintIdentifier = "80AD1A3B2473E806001DA4E2"
+               BuildableName = "PerformanceTests.xctest"
+               BlueprintName = "PerformanceTests"
                ReferencedContainer = "container:Trace.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Trace/Configuration/TraceConfigurationInteractor.swift
+++ b/Trace/Configuration/TraceConfigurationInteractor.swift
@@ -43,7 +43,7 @@ internal struct TraceConfigurationInteractor {
             result = false
         }
         
-        #if Debug
+        #if DEBUG || Debug || debug
         // Check XCode environment variables. this only works when running with a debugger i.e in Run app or Tests
         let environment = ProcessInfo.processInfo.environment
         

--- a/Trace/Library/API/Crashes/CrashesService.swift
+++ b/Trace/Library/API/Crashes/CrashesService.swift
@@ -37,6 +37,10 @@ internal struct CrashesService {
         let name = model.title
         let file = model.report
         
+        if parameters == nil {
+            Logger.print(.crash, "Could not create crash report model")
+        }
+        
         return network.upload(router, name: name, file: file, parameters: parameters) {
             completion($0)
         }

--- a/Trace/Library/Database/CRUD.swift
+++ b/Trace/Library/Database/CRUD.swift
@@ -48,8 +48,7 @@ internal protocol CRUD {
     
     // MARK: - Delete
     
-    func delete(_ object: T)
-    func delete(_ objects: [T])
+    func delete(_ objects: [NSManagedObjectID])
 }
 
 /// Helper to manage database objects without repeating code
@@ -93,40 +92,13 @@ internal extension CRUD where T: NSManagedObject {
     
     // MARK: - Delete
     
-    func delete(_ object: T) {
-        delete([object])
-    }
-    
-    func delete(_ objects: [T]) {
-        persistent.privateContext.perform {
-            let context = self.persistent.privateContext
-            
-            // delete
-            objects.forEach {
-                let backgroundObject = context.object(with: $0.objectID)
-                
-                context.delete(backgroundObject)
-            }
-            
-            // save
-            try? context.save()
-            
-            if self.test_completion != nil {
-                DispatchQueue.main.async { self.test_completion?() }
-            }
-        }
-    }
-    
     func delete(_ ids: [NSManagedObjectID]) {
         let context = persistent.privateContext
-        
         context.perform {
             let objects: [NSManagedObject] = ids.compactMap {
                 do {
                     return try context.existingObject(with: $0)
                 } catch {
-                    Logger.print(.database, "Failed to find object with id: \(error.localizedDescription)")
-                    
                     return nil
                 }
             }

--- a/Trace/Library/Database/CRUD.swift
+++ b/Trace/Library/Database/CRUD.swift
@@ -116,6 +116,35 @@ internal extension CRUD where T: NSManagedObject {
             }
         }
     }
+    
+    func delete(_ ids: [NSManagedObjectID]) {
+        let context = persistent.privateContext
+        
+        context.perform {
+            let objects: [NSManagedObject] = ids.compactMap {
+                do {
+                    return try context.existingObject(with: $0)
+                } catch {
+                    Logger.print(.database, "Failed to find object with id: \(error.localizedDescription)")
+                    
+                    return nil
+                }
+            }
+            
+            objects.forEach { context.delete($0) }
+            
+            // save
+            do {
+                try context.save()
+            } catch {
+                Logger.print(.database, "Failed to save database")
+            }
+            
+            if self.test_completion != nil {
+                DispatchQueue.main.async { self.test_completion?() }
+            }
+        }
+    }
 }
 
 /// Fetch

--- a/Trace/Library/Database/CRUD.swift
+++ b/Trace/Library/Database/CRUD.swift
@@ -157,17 +157,18 @@ internal extension CRUD where T: NSManagedObject {
     // MARK: - Count
     
     func count(in context: Database.Context) -> Int {
-        let managedObjectContext = context.managedObjectContext(for: persistent)
-        
-        let request = fetchRequest
-        request.resultType = .countResultType
-        
         var count = 0
         
-        do {
-            count = try managedObjectContext.count(for: request)
-        } catch {
-            Logger.print(.database, "Cannot count DB record: \(error.localizedDescription)")
+        let managedObjectContext = context.managedObjectContext(for: persistent)
+        managedObjectContext.performAndWait {
+            let request = fetchRequest
+            request.resultType = .countResultType
+            
+            do {
+                count = try managedObjectContext.count(for: request)
+            } catch {
+                Logger.print(.database, "Cannot count DB record: \(error.localizedDescription)")
+            }
         }
         
         return count
@@ -177,18 +178,19 @@ internal extension CRUD where T: NSManagedObject {
     
     // pecker:ignore
     func one(in context: Database.Context, where predicate: NSPredicate?=nil) -> T? {
-        let managedObjectContext = context.managedObjectContext(for: persistent)
-        
-        let request = fetchRequest
-        request.fetchLimit = 1
-        request.predicate = predicate
-        
         var model: T?
         
-        do {
-            model = try managedObjectContext.fetch(request).first
-        } catch {
-            Logger.print(.database, "Cannot fetch single request: \(error.localizedDescription)")
+        let managedObjectContext = context.managedObjectContext(for: persistent)
+        managedObjectContext.performAndWait {
+            let request = fetchRequest
+            request.fetchLimit = 1
+            request.predicate = predicate
+            
+            do {
+                model = try managedObjectContext.fetch(request).first
+            } catch {
+                Logger.print(.database, "Cannot fetch single request: \(error.localizedDescription)")
+            }
         }
         
         return model
@@ -196,24 +198,25 @@ internal extension CRUD where T: NSManagedObject {
     
     // pecker:ignore
     func all(in context: Database.Context, where predicate: NSPredicate?=nil, sort sortDescriptors: [NSSortDescriptor]?=nil, limit: Int?=nil) -> [T] {
-        let managedObjectContext = context.managedObjectContext(for: persistent)
-        
-        let request = fetchRequest
-        request.predicate = predicate
-        request.sortDescriptors = sortDescriptors
-        
-        if let limit = limit {
-            request.fetchLimit = limit
-        }
-        
         var all = [T]()
         
-        do {
-            let records = try managedObjectContext.fetch(request)
+        let managedObjectContext = context.managedObjectContext(for: persistent)
+        managedObjectContext.performAndWait {
+            let request = fetchRequest
+            request.predicate = predicate
+            request.sortDescriptors = sortDescriptors
             
-            all.append(contentsOf: records)
-        } catch {
-            Logger.print(.database, "Cannot fetch request: \(error.localizedDescription)")
+            if let limit = limit {
+                request.fetchLimit = limit
+            }
+            
+            do {
+                let records = try managedObjectContext.fetch(request)
+                
+                all.append(contentsOf: records)
+            } catch {
+                Logger.print(.database, "Cannot fetch request: \(error.localizedDescription)")
+            }
         }
         
         return all

--- a/Trace/Library/Database/Database.swift
+++ b/Trace/Library/Database/Database.swift
@@ -96,6 +96,7 @@ final internal class Database {
         // Test only
         if hasMemoryPersistent {
             persistent.viewContext.reset()
+            persistent.newBackgroundContext().reset()
             
             persistent.persistentStoreCoordinator.persistentStores.forEach {
                 try? persistent.persistentStoreCoordinator.remove($0)

--- a/Trace/Library/Database/MetricDAO.swift
+++ b/Trace/Library/Database/MetricDAO.swift
@@ -60,9 +60,9 @@ internal final class MetricDAO: CRUD {
     ///
     /// - Parameter models: data models
     func create(with models: [M], save: Bool, synchronous: Bool) {
+        let context = persistent.privateContext
+        
         let function: () -> Void = {
-            let context = self.persistent.privateContext
-            
             do {
                 let _: [T?] = try models.map {
                     let date = Date()
@@ -99,9 +99,9 @@ internal final class MetricDAO: CRUD {
         }
         
         if synchronous {
-            persistent.privateContext.performAndWait(function)
+            context.performAndWait(function)
         } else {
-            persistent.privateContext.perform(function)
+            context.perform(function)
         }
     }
 }

--- a/Trace/Library/Database/MetricDAO.swift
+++ b/Trace/Library/Database/MetricDAO.swift
@@ -91,7 +91,9 @@ internal final class MetricDAO: CRUD {
                 if let affectedObjects = cocoaError.userInfo[key] as? [T] {
                     Logger.print(.database, "Writting metric failed. Removing affected objects \(affectedObjects.count)")
                     
-                    self.delete(affectedObjects)
+                    let affectedObjectIds = affectedObjects.map { $0.objectID }
+                    
+                    self.delete(affectedObjectIds)
                 }
             }
         }

--- a/Trace/Library/Database/Persistent.swift
+++ b/Trace/Library/Database/Persistent.swift
@@ -18,7 +18,7 @@ final internal class Persistent: NSPersistentContainer {
     
     // MARK: - Property
     
-    lazy var privateContext: NSManagedObjectContext = self.newBackgroundContext()
+    var privateContext: NSManagedObjectContext { self.newBackgroundContext() }
     
     // MARK: - Setup
     

--- a/Trace/Library/Database/TraceDAO.swift
+++ b/Trace/Library/Database/TraceDAO.swift
@@ -53,9 +53,9 @@ internal final class TraceDAO: CRUD {
     ///
     /// - Parameter models: data models
     func create(with models: [M], save: Bool, synchronous: Bool) {
+        let context = persistent.privateContext
+        
         let function: () -> Void = {
-            let context = self.persistent.privateContext
-            
             do {
                 let _: [T?] = try models.map {
                     let date = Date()
@@ -92,9 +92,9 @@ internal final class TraceDAO: CRUD {
         }
         
         if synchronous {
-            persistent.privateContext.performAndWait(function)
+            context.performAndWait(function)
         } else {
-            persistent.privateContext.perform(function)
+            context.perform(function)
         }
     }
 }

--- a/Trace/Library/Database/TraceDAO.swift
+++ b/Trace/Library/Database/TraceDAO.swift
@@ -84,7 +84,9 @@ internal final class TraceDAO: CRUD {
                 if let affectedObjects = cocoaError.userInfo[key] as? [T] {
                     Logger.print(.database, "Writting trace failed. Removing affected objects \(affectedObjects.count)")
                     
-                    self.delete(affectedObjects)
+                    let affectedObjectIds = affectedObjects.map { $0.objectID }
+                    
+                    self.delete(affectedObjectIds)
                 }
             }
         }

--- a/Trace/Library/Time/Time.swift
+++ b/Trace/Library/Time/Time.swift
@@ -42,7 +42,7 @@ internal enum Time {
         // MARK: - Setup
         
         private func setup() {
-            #if Debug
+            #if DEBUG || Debug || debug
                 // TODO: only for private beta testing. remove before GA
                 if !TimestampValidator(toDate: Date()).isValid(seconds: seconds, nanos: nanos) {
                     Logger.print(.internalError, "Timestamp \(seconds).\(nanos) is invalid")

--- a/Trace/Metric/Metric+Timeseries+Point.swift
+++ b/Trace/Metric/Metric+Timeseries+Point.swift
@@ -90,7 +90,7 @@ internal extension Metric.Timeseries {
         // MARK: - Setup
         
         private func setup() {
-            #if Debug
+            #if DEBUG || Debug || debug
                 // TODO: only for private beta testing. remove before GA
                 if !TimestampValidator(toDate: Date()).isValid(seconds: seconds, nanos: nanos) {
                     Logger.print(.internalError, "Timestamp \(seconds).\(nanos) is invalid")

--- a/Trace/Queue/Queue.swift
+++ b/Trace/Queue/Queue.swift
@@ -101,12 +101,13 @@ internal final class Queue {
                 }
                 
                 let model = Metrics(combined, resource: resource, attributes: attributes)
+                let dbModelObjectIds = dbModels.map { $0.objectID }
                 
                 Logger.print(.queue, "Scheduling \(combined.count) metrics from \(dbModels.count). Type: \(names.joined(separator: ", "))")
                 
                 self?.scheduler.schedule(model, {
                     switch $0 {
-                    case .success: self?.database.dao.metric.delete(dbModels)
+                    case .success: self?.database.dao.metric.delete(dbModelObjectIds)
                     case .failure: Logger.print(.queue, "Failed to submit metric, will try again in 1 minute")
                     }
                 })

--- a/Trace/Queue/Queue.swift
+++ b/Trace/Queue/Queue.swift
@@ -109,16 +109,7 @@ internal final class Queue {
                     switch $0 {
                     case .success:
                         let dao = self?.database.dao.metric
-                        
-                        #if DEBUG || Debug || debug
-                        Logger.print(.database, "Metric count before delete: \(dao?.count(in: .background) ?? 0)")
-                        #endif
-                        
                         dao?.delete(dbModelObjectIds)
-                        
-                        #if DEBUG || Debug || debug
-                        Logger.print(.database, "Metric count after delete: \(dao?.count(in: .background) ?? 0)")
-                        #endif
                     case .failure:
                         Logger.print(.queue, "Failed to submit metric, will try again in 1 minute")
                     }
@@ -170,16 +161,7 @@ internal final class Queue {
                         switch $0 {
                         case .success:
                             let dao = self?.database.dao.trace
-                            
-                            #if DEBUG || Debug || debug
-                            Logger.print(.database, "Trace count before delete: \(dao?.count(in: .background) ?? 0)")
-                            #endif
-                            
                             dao?.delete(toBeDeletedObjectIds)
-                            
-                            #if DEBUG || Debug || debug
-                            Logger.print(.database, "Trace count after delete: \(dao?.count(in: .background) ?? 0)")
-                            #endif
                         case .failure:
                             Logger.print(.queue, "Failed to submit trace, will try again in 1 minute")
                         }
@@ -206,10 +188,6 @@ internal final class Queue {
                 if let second = components.second, second >= Queue.timeout {
                     save = true
                     self?.lastSave = Date()
-                    
-                    #if DEBUG || Debug || debug
-                    Logger.print(.database, "Metric count before save: \(dao?.count(in: .background) ?? 0)")
-                    #endif
                 } else {
                     save = false
                 }
@@ -219,12 +197,6 @@ internal final class Queue {
                 with: metrics,
                 save: save
             )
-            
-            if save {
-                #if DEBUG || Debug || debug
-                Logger.print(.database, "Metric count after save: \(dao?.count(in: .background) ?? 0)")
-                #endif
-            }
             
             if force {
                 self?.schedule()
@@ -253,10 +225,6 @@ internal final class Queue {
                 if let second = components.second, second >= Queue.timeout {
                     save = true
                     self?.lastSave = Date()
-                    
-                    #if DEBUG || Debug || debug
-                    Logger.print(.database, "Trace count before save: \(dao?.count(in: .background) ?? 0)")
-                    #endif
                 } else {
                     save = false
                 }
@@ -275,12 +243,6 @@ internal final class Queue {
             }
             
             dao?.create(with: traces, save: save, synchronous: false)
-            
-            if save {
-                #if DEBUG || Debug || debug
-                Logger.print(.database, "Trace count after save: \(dao?.count(in: .background) ?? 0)")
-                #endif
-            }
             
             if force {
                 self?.schedule()

--- a/Trace/TraceModel/TraceModel+Span.swift
+++ b/Trace/TraceModel/TraceModel+Span.swift
@@ -69,7 +69,7 @@ extension TraceModel {
             // MARK: - Setup
             
             private func setup() {
-                #if Debug
+                #if DEBUG || Debug || debug
                 // TODO: only for private beta testing. remove before GA
                 if !TimestampValidator(toDate: Date()).isValid(seconds: seconds, nanos: nanos) {
                     Logger.print(.internalError, "Timestamp \(seconds).\(nanos) is invalid")
@@ -315,7 +315,7 @@ extension TraceModel {
             try container.encode(end, forKey: .end)
             try container.encode(attribute, forKey: .attributes)
             
-            #if Debug
+            #if DEBUG || Debug || debug
             // TODO: only for private beta testing. remove before GA
             validate()
             #endif

--- a/iOSDemo/iOSDemoUITests/iOSDemoUITests.swift
+++ b/iOSDemo/iOSDemoUITests/iOSDemoUITests.swift
@@ -26,7 +26,7 @@ final class iOSDemoUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
-        sleep(45)
+        sleep(10)
         
         let result = app.wait(for: .runningForeground, timeout: 5)
         


### PR DESCRIPTION
## Proposed changes:
- New tests for CRUD
- New tests for Trace and Metric DAO
- Fixed tests that depended on `Database` object
- Core data flags in Xcode scheme, disabled by default
- Improved debug check i.e `#if DEBUG || Debug || debug`
- Made sure all DB read/write used there own thread using `perform` method
- Pass NSManagedObjectID instead of native DB object to avoid threading issue
- Create new DB private context instead of reusing current context thread
- Expose DB errors

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
