### PR TITLE
Add Resource fields to form field header

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ echo "Bitrise Trace SDK - starting Upload dSYM's"
 # See script header for more information - https://github.com/bitrise-io/trace-cocoa-sdk/blob/main/UploadDSYM/main.swift#L4
 
 # Run script
-/usr/bin/xcrun --sdk macosx swift <(curl -Ls --retry 3 --connect-timeout 20 https://raw.githubusercontent.com/bitrise-io/trace-cocoa-sdk/main/UploadDSYM/main.swift)
+/usr/bin/xcrun --sdk macosx swift <(curl -Ls --retry 3 --connect-timeout 20 -H "Cache-Control: max-age=604800" https://raw.githubusercontent.com/bitrise-io/trace-cocoa-sdk/main/UploadDSYM/main.swift)
 
 echo "Bitrise Trace SDK - finished Upload dSYM's"
 ```
@@ -240,7 +240,7 @@ You must first download the zipped dSYM's files from iTunes Connect under Activi
 Open Terminal app and run the following command:
 Remote script
 ```
-/usr/bin/xcrun --sdk macosx swift <(curl -Ls --retry 3 --connect-timeout 20 https://raw.githubusercontent.com/bitrise-io/trace-cocoa-sdk/main/UploadDSYM/main.swift) APM_DSYM_PATH appDsyms.zip
+/usr/bin/xcrun --sdk macosx swift <(curl -Ls --retry 3 --connect-timeout 20 -H "Cache-Control: max-age=604800" https://raw.githubusercontent.com/bitrise-io/trace-cocoa-sdk/main/UploadDSYM/main.swift) APM_DSYM_PATH appDsyms.zip
 ```
 Local script 
 ```

--- a/Tests/AppleCrashFormatInterpreterTests.swift
+++ b/Tests/AppleCrashFormatInterpreterTests.swift
@@ -75,6 +75,20 @@ final class AppleCrashFormatInterpreterTests: XCTestCase {
                 XCTAssertNotNil(model.timestamp)
                 XCTAssertFalse(model.id.isEmpty)
                 XCTAssertFalse(model.timestamp.isEmpty)
+                XCTAssertNotNil(model.appVersion)
+                XCTAssertNotNil(model.buildVersion)
+                XCTAssertNotNil(model.osVersion)
+                XCTAssertTrue(!model.deviceType.isEmpty)
+                XCTAssertNotNil(model.sessionId)
+                XCTAssertTrue(!model.eventIdentifier.isEmpty)
+                XCTAssertNotNil(model.network)
+                XCTAssertNotNil(model.carrier)
+                XCTAssertTrue(!model.deviceId.isEmpty)
+                
+                XCTAssertFalse(model.deviceType.contains("\""))
+                XCTAssertFalse(model.network.contains("\""))
+                XCTAssertFalse(model.carrier.contains("\""))
+                XCTAssertFalse(model.deviceId.contains("\""))
             }
         } catch {
             XCTFail("Could not open crash file")
@@ -138,6 +152,26 @@ final class AppleCrashFormatInterpreterTests: XCTestCase {
                 
                 XCTAssertTrue(model.id.isEmpty)
             }
+        } catch {
+            XCTFail("Could not open crash file")
+        }
+    }
+    
+    func testCreateModel_InStringFormat() {
+        guard let url = Bundle(for: Self.self).url(forResource: "traceIdEmpty", withExtension: "crash") else {
+            return XCTFail("Could not locate test fails")
+        }
+        
+        do {
+            let data = try Data(contentsOf: url)
+            let string = String(data: data, encoding: .utf8)!
+            
+            XCTAssertNotNil(string)
+            
+            XCTAssertTrue(string.contains("SDK Event Identifier:"))
+            XCTAssertTrue(string.contains("Build Version:"))
+            XCTAssertTrue(string.contains("App Version:"))
+            XCTAssertTrue(string.contains("app.session.id"))
         } catch {
             XCTFail("Could not open crash file")
         }

--- a/Tests/CrashesServiceTests.swift
+++ b/Tests/CrashesServiceTests.swift
@@ -81,7 +81,22 @@ final class CrashesServiceTests: XCTestCase {
         let network = MockNetwork()
         let service = CrashesService(network: network)
         let report = "Crash report here...".data(using: .utf8)!
-        let model = Crash(id: "123", timestamp: "2020-03-11 16:35:29.357 +0000", title: "test", report: report)
+        let model = Crash(
+            id: "123",
+            timestamp: "2020-03-11 16:35:29.357 +0000",
+            title: "test",
+            appVersion: "1.0.0",
+            buildVersion: "1",
+            osVersion: "iOS 13",
+            deviceType: "iPhone",
+            sessionId: "12345-12345",
+            network: "wifi",
+            carrier: "",
+            deviceId: "12345-12345",
+            eventIdentifier:"12345-12345",
+            crashedWithoutSession: false,
+            report: report
+        )
         
         network.status = .success
         
@@ -102,7 +117,22 @@ final class CrashesServiceTests: XCTestCase {
         let network = MockNetwork()
         let service = CrashesService(network: network)
         let report = "Crash report here...".data(using: .utf8)!
-        let model = Crash(id: "123", timestamp: "2020-03-11 16:35:29.357 +0000", title: "test", report: report)
+        let model = Crash(
+            id: "123",
+            timestamp: "2020-03-11 16:35:29.357 +0000",
+            title: "test",
+            appVersion: "1.0.0",
+            buildVersion: "1",
+            osVersion: "iOS 13",
+            deviceType: "iPhone",
+            sessionId: "12345-12345",
+            network: "wifi",
+            carrier: "",
+            deviceId: "12345-12345",
+            eventIdentifier:"12345-12345",
+            crashedWithoutSession: false,
+            report: report
+        )
         
         network.status = .failure
         

--- a/Tests/CrashesTest.swift
+++ b/Tests/CrashesTest.swift
@@ -26,7 +26,22 @@ final class CrashesTests: XCTestCase {
     
     func testCrashes() {
         let report = Data()
-        let crash = Crash(id: "123", timestamp: "2020-03-11 16:35:29.357 +0000", title: "test", report: report)
+        let crash = Crash(
+            id: "123",
+            timestamp: "2020-03-11 16:35:29.357 +0000",
+            title: "test",
+            appVersion: "1.0.0",
+            buildVersion: "1",
+            osVersion: "iOS 13",
+            deviceType: "iPhone",
+            sessionId: "12345-12345",
+            network: "wifi",
+            carrier: "",
+            deviceId: "12345-12345",
+            eventIdentifier:"12345-12345",
+            crashedWithoutSession: false,
+            report: report
+        )
         
         XCTAssertNotNil(crash)
         XCTAssertNotNil(crash.report)
@@ -36,17 +51,47 @@ final class CrashesTests: XCTestCase {
     
     func testCrashes_dictionary() {
         let report = Data()
-        let crash = Crash(id: "123", timestamp: "2020-03-11 16:35:29.357 +0000", title: "test", report: report)
+        let crash = Crash(
+            id: "123",
+            timestamp: "2020-03-11 16:35:29.357 +0000",
+            title: "test",
+            appVersion: "1.0.0",
+            buildVersion: "1",
+            osVersion: "iOS 13",
+            deviceType: "iPhone",
+            sessionId: "12345-12345",
+            network: "wifi",
+            carrier: "",
+            deviceId: "12345-12345",
+            eventIdentifier:"12345-12345",
+            crashedWithoutSession: false,
+            report: report
+        )
         
         let dict = try? crash.dictionary()
         
         XCTAssertNotNil(dict)
-        XCTAssertEqual(dict?.count, 3)
+        XCTAssertEqual(dict?.count, 13)
     }
     
     func testCrashes_json() {
         let report = Data()
-        let crash = Crash(id: "123", timestamp: "2020-03-11 16:35:29.357 +0000", title: "test", report: report)
+        let crash = Crash(
+            id: "123",
+            timestamp: "2020-03-11 16:35:29.357 +0000",
+            title: "test",
+            appVersion: "1.0.0",
+            buildVersion: "1",
+            osVersion: "iOS 13",
+            deviceType: "iPhone",
+            sessionId: "12345-12345",
+            network: "wifi",
+            carrier: "",
+            deviceId: "12345-12345",
+            eventIdentifier:"12345-12345",
+            crashedWithoutSession: false,
+            report: report
+        )
         
         let json = try? crash.json()
         

--- a/Tests/SessionTests.swift
+++ b/Tests/SessionTests.swift
@@ -71,7 +71,7 @@ final class SessionTests: XCTestCase {
         
         XCTAssertNotNil(current.resource)
         XCTAssertEqual(current.resource!.type, "mobile")
-        XCTAssertEqual(current.resource!.platform, "iOS")
+        XCTAssertEqual(current.resource!.platform, "")
         XCTAssertEqual(current.resource!.appVersion, "")
         XCTAssertEqual(current.resource!.uuid, "")
         XCTAssertEqual(current.resource!.osVersion, "")
@@ -79,7 +79,8 @@ final class SessionTests: XCTestCase {
         XCTAssertEqual(current.resource!.carrier, "")
         XCTAssertEqual(current.resource!.jailbroken, "")
         XCTAssertEqual(current.resource!.sdkVersion, "")
-        XCTAssertEqual(current.resource!.network, "")
+        
+        XCTAssertNotNil(current.resource!.network)
         XCTAssertFalse(current.resource!.session.isEmpty)
     }
     
@@ -93,7 +94,7 @@ final class SessionTests: XCTestCase {
         
         XCTAssertNotNil(current.resource)
         XCTAssertEqual(current.resource!.type, "mobile")
-        XCTAssertEqual(current.resource!.platform, "iOS")
+        XCTAssertEqual(current.resource!.platform, "")
         XCTAssertEqual(current.resource!.appVersion, "")
         XCTAssertEqual(current.resource!.uuid, "")
         XCTAssertEqual(current.resource!.osVersion, "")
@@ -115,7 +116,7 @@ final class SessionTests: XCTestCase {
         
         XCTAssertNotNil(current.resource)
         XCTAssertEqual(current.resource!.type, "mobile")
-        XCTAssertEqual(current.resource!.platform, "iOS")
+        XCTAssertEqual(current.resource!.platform, "")
         XCTAssertEqual(current.resource!.appVersion, "")
         XCTAssertEqual(current.resource!.uuid, "")
         XCTAssertEqual(current.resource!.osVersion, "")
@@ -137,7 +138,7 @@ final class SessionTests: XCTestCase {
         
         XCTAssertNotNil(current.resource)
         XCTAssertEqual(current.resource!.type, "mobile")
-        XCTAssertEqual(current.resource!.platform, "iOS")
+        XCTAssertEqual(current.resource!.platform, "")
         XCTAssertEqual(current.resource!.appVersion, "")
         XCTAssertEqual(current.resource!.uuid, "")
         XCTAssertEqual(current.resource!.osVersion, "")
@@ -163,7 +164,7 @@ final class SessionTests: XCTestCase {
         
         XCTAssertNotNil(current.resource)
         XCTAssertEqual(current.resource!.type, "mobile")
-        XCTAssertEqual(current.resource!.platform, "iOS")
+        XCTAssertEqual(current.resource!.platform, "")
         XCTAssertEqual(current.resource!.appVersion, "")
         XCTAssertEqual(current.resource!.uuid, "")
         XCTAssertEqual(current.resource!.osVersion, "")
@@ -193,7 +194,7 @@ final class SessionTests: XCTestCase {
         
         XCTAssertNotNil(current.resource)
         XCTAssertEqual(current.resource!.type, "mobile")
-        XCTAssertEqual(current.resource!.platform, "iOS")
+        XCTAssertEqual(current.resource!.platform, "")
         XCTAssertEqual(current.resource!.appVersion, "")
         XCTAssertEqual(current.resource!.uuid, "")
         XCTAssertEqual(current.resource!.osVersion, "")

--- a/Tests/Supporting Files/noTraceId.crash
+++ b/Tests/Supporting Files/noTraceId.crash
@@ -1,4 +1,4 @@
-Incident Identifier: 3A5D8253-FDC8-44DC-910A-30F83C502B08
+SDK Event Identifier: 3A5D8253-FDC8-44DC-910A-30F83C502B08
 CrashReporter Key:   316c5b2204000efe35257619b15762a6bd29b3e1
 Hardware Model:      iPhone12,1
 Process:         iOSDemo [1348]

--- a/Tests/Supporting Files/noTraceId.crash
+++ b/Tests/Supporting Files/noTraceId.crash
@@ -5,6 +5,8 @@ Process:         iOSDemo [1348]
 Path:            /Users/shamsahmed/Library/Developer/CoreSimulator/Devices/DA781C5B-C3EA-4A4F-A55E-8030DFC8A2D3/data/Containers/Bundle/Application/CA25249D-5A1D-41AC-AB43-99A739789E0E/iOSDemo.app/iOSDemo
 Identifier:      io.bitrise.iOSDemo
 Version:         1 (1.0.0)
+App Version:         1.0.0
+Build Version:         1
 Code Type:       X86
 Parent Process:  ? [90972]
 

--- a/Tests/Supporting Files/outOfBound.crash
+++ b/Tests/Supporting Files/outOfBound.crash
@@ -1,4 +1,4 @@
-Incident Identifier: 3A5D8253-FDC8-44DC-910A-30F83C502B08
+SDK Event Identifier: 3A5D8253-FDC8-44DC-910A-30F83C502B08
 CrashReporter Key:   316c5b2204000efe35257619b15762a6bd29b3e1
 Hardware Model:      iPhone12,1
 Process:         iOSDemo [1348]

--- a/Tests/Supporting Files/outOfBound.crash
+++ b/Tests/Supporting Files/outOfBound.crash
@@ -5,6 +5,8 @@ Process:         iOSDemo [1348]
 Path:            /Users/shamsahmed/Library/Developer/CoreSimulator/Devices/DA781C5B-C3EA-4A4F-A55E-8030DFC8A2D3/data/Containers/Bundle/Application/CA25249D-5A1D-41AC-AB43-99A739789E0E/iOSDemo.app/iOSDemo
 Identifier:      io.bitrise.iOSDemo
 Version:         1 (1.0.0)
+App Version:         1.0.0
+Build Version:         1
 Code Type:       X86
 Parent Process:  ? [90972]
 

--- a/Tests/Supporting Files/traceIdEmpty.crash
+++ b/Tests/Supporting Files/traceIdEmpty.crash
@@ -1,4 +1,4 @@
-Incident Identifier: 3A5D8253-FDC8-44DC-910A-30F83C502B08
+SDK Event Identifier: 3A5D8253-FDC8-44DC-910A-30F83C502B08
 CrashReporter Key:   316c5b2204000efe35257619b15762a6bd29b3e1
 Hardware Model:      iPhone12,1
 Process:         iOSDemo [1348]

--- a/Tests/Supporting Files/traceIdEmpty.crash
+++ b/Tests/Supporting Files/traceIdEmpty.crash
@@ -5,6 +5,8 @@ Process:         iOSDemo [1348]
 Path:            /Users/shamsahmed/Library/Developer/CoreSimulator/Devices/DA781C5B-C3EA-4A4F-A55E-8030DFC8A2D3/data/Containers/Bundle/Application/CA25249D-5A1D-41AC-AB43-99A739789E0E/iOSDemo.app/iOSDemo
 Identifier:      io.bitrise.iOSDemo
 Version:         1 (1.0.0)
+App Version:         1.0.0
+Build Version:         1
 Code Type:       X86
 Parent Process:  ? [90972]
 

--- a/Trace.xcodeproj/project.pbxproj
+++ b/Trace.xcodeproj/project.pbxproj
@@ -3839,7 +3839,6 @@
 			shellPath = "/usr/bin/xcrun --sdk macosx swift $(SRCROOT)/UploadDSYM/main.swift";
 			shellScript = "
 ";
-			showEnvVarsInLog = 0;
 		};
 		1086A8B225641036007612D0 /* 4. Create VERSION file */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Trace/Hardware/Device/DeviceFormatter.swift
+++ b/Trace/Hardware/Device/DeviceFormatter.swift
@@ -86,7 +86,31 @@ internal struct DeviceFormatter: JSONEncodable {
         
         details[Keys.model.rawValue] = device.getModelName()
         details[Keys.systemVersion.rawValue] = device.systemVersion
-        details[Keys.platform.rawValue] = "iOS"
+        
+        var platform: String
+        
+        #if os(OSX)
+            platform = "macOS"
+        #elseif os(watchOS)
+            platform = "watchOS"
+        #elseif os(tvOS)
+            platform = "tvOS"
+        #elseif os(iOS)
+            #if targetEnvironment(macCatalyst)
+                platform = "macCatalyst"
+            #else
+                platform = "iOS"
+            #endif
+        #else
+        Logger.debug(.application, "Unknown")
+            platform = "Unknown"
+        #endif
+        
+        if device.userInterfaceIdiom == .pad {
+            platform = "iPadOS"
+        }
+        
+        details[Keys.platform.rawValue] = platform
         
         let locale = Locale.current
         

--- a/Trace/Hardware/Session.swift
+++ b/Trace/Hardware/Session.swift
@@ -31,7 +31,7 @@ final class Session {
             
             if let resources = try? resource?.dictionary() {
                 // TODO: use enum instead of string
-                Trace.shared.crash.userInfo["Resource"] = resources
+                Trace.shared.crash.userInfo[CrashController.Keys.resource.rawValue] = resources
             }
         }
     }

--- a/Trace/Library/CrashReportingSwift/AppleCrashFormatInterpreter.swift
+++ b/Trace/Library/CrashReportingSwift/AppleCrashFormatInterpreter.swift
@@ -23,6 +23,15 @@ internal struct AppleCrashFormatInterpreter {
         
         var id = ""
         var timestamp = ""
+        var appVersion = ""
+        var buildVersion = ""
+        var osVersion = ""
+        var deviceType = ""
+        var sessionId = ""
+        var eventIdentifier = ""
+        var network = ""
+        var carrier = ""
+        var deviceId = ""
     }
     
     // MARK: - Enum
@@ -35,6 +44,15 @@ internal struct AppleCrashFormatInterpreter {
     private enum Patten: String, CaseIterable {
         case id = "\\w*Trace Id: \\w*"
         case timestamp = "\\w*Date\\/Time:.*[0.9]"
+        case appVersion = "\\w*App Version:.*"
+        case buildVersion = "\\w*Build Version:.*"
+        case osVersion = "\\w*\"os.version\": \".*\""
+        case deviceType = "\\w*\"device.type\": .*\""
+        case sessionId = "\\w*\"app.session.id\": .*\""
+        case eventIdentifier = "\\w*SDK Event Identifier: .*"
+        case network = "\\w*\"device.network\": \".*\""
+        case carrier = "\\w*\"device.carrier\": \".*\""
+        case deviceId = "\\w*\"device.id\": \".*\""
     }
     
     // MARK: - Property
@@ -77,6 +95,36 @@ internal struct AppleCrashFormatInterpreter {
                         model.id = value.replacingOccurrences(of: "Trace Id: ", with: "")
                     case .timestamp:
                         model.timestamp = value.replacingOccurrences(of: "Date/Time:       ", with: "")
+                    case .appVersion:
+                        model.appVersion = value.replacingOccurrences(of: "App Version:         ", with: "")
+                    case .buildVersion:
+                        model.buildVersion = value.replacingOccurrences(of: "Build Version:         ", with: "")
+                    case .osVersion:
+                        model.osVersion = value
+                            .replacingOccurrences(of: "\"os.version\": \"", with: "")
+                            .replacingOccurrences(of: "\"", with: "")
+                    case .deviceType:
+                        model.deviceType = value
+                            .replacingOccurrences(of: "\"device.type\": \"", with: "")
+                            .replacingOccurrences(of: "\"", with: "")
+                    case .sessionId:
+                        model.sessionId = value
+                            .replacingOccurrences(of: "\"app.session.id\": \"", with: "")
+                            .replacingOccurrences(of: "\"", with: "")
+                    case .eventIdentifier:
+                        model.eventIdentifier = value.replacingOccurrences(of: "SDK Event Identifier: ", with: "")
+                    case .network:
+                        model.network = value
+                            .replacingOccurrences(of: "\"device.network\": \"", with: "")
+                            .replacingOccurrences(of: "\"", with: "")
+                    case .carrier:
+                        model.carrier = value
+                            .replacingOccurrences(of: "\"device.carrier\": \"", with: "")
+                            .replacingOccurrences(of: "\"", with: "")
+                    case .deviceId:
+                        model.deviceId = value
+                            .replacingOccurrences(of: "\"device.id\": \"", with: "")
+                            .replacingOccurrences(of: "\"", with: "")
                     }
                 }
             }

--- a/Trace/Library/CrashReportingSwift/Crash.swift
+++ b/Trace/Library/CrashReportingSwift/Crash.swift
@@ -14,9 +14,20 @@ internal struct Crash: Encodable {
     // MARK: - Enum
     
     private enum CodingKeys: String, CodingKey {
+        case report
         case id = "trace_id"
         case title
         case timestamp
+        case appVersion = "app_version"
+        case buildVersion = "build_id"
+        case OSVersion = "os_version"
+        case deviceType = "device_type"
+        case sessionId = "session_id"
+        case network = "device_network"
+        case carrier = "device_carrier"
+        case deviceId = "device_id"
+        case crashedWithoutSession = "crashed_without_session"
+        case eventIdentifier = "sdk_event_identifier"
     }
     
     // MARK: - Property
@@ -24,6 +35,16 @@ internal struct Crash: Encodable {
     internal let id: String
     internal let timestamp: String
     internal let title: String
+    internal let appVersion: String
+    internal let buildVersion: String
+    internal let osVersion: String
+    internal let deviceType: String
+    internal let sessionId: String
+    internal let network: String
+    internal let carrier: String
+    internal let deviceId: String
+    internal let eventIdentifier: String
+    internal let crashedWithoutSession: Bool
     
     /// Sent as multipart form data
     internal let report: Data
@@ -36,5 +57,17 @@ internal struct Crash: Encodable {
         try container.encode(id, forKey: .id)
         try container.encode(timestamp, forKey: .timestamp)
         try container.encode(title, forKey: .title)
+        try container.encode(appVersion, forKey: .appVersion)
+        try container.encode(buildVersion, forKey: .buildVersion)
+        try container.encode(osVersion, forKey: .OSVersion)
+        try container.encode(deviceType, forKey: .deviceType)
+        try container.encode(sessionId, forKey: .sessionId)
+        try container.encode(network, forKey: .network)
+        try container.encode(carrier, forKey: .carrier)
+        try container.encode(deviceId, forKey: .deviceId)
+        try container.encode(eventIdentifier, forKey: .eventIdentifier)
+        try container.encode(crashedWithoutSession, forKey: .crashedWithoutSession)
+        
+        // Report not required
     }
 }

--- a/Trace/Library/CrashReportingSwift/CrashController.swift
+++ b/Trace/Library/CrashReportingSwift/CrashController.swift
@@ -92,10 +92,23 @@ public final class CrashController: NSObject {
             // Create model out of the raw Apple format.
             // Since it all string based it isn't easy to handle like JSON and plist
             let model = try interpreter.toModel().get()
-            let crash = Crash(id: model.id,
-                              timestamp: model.timestamp,
-                              title: "Crash_report",
-                              report: report
+            let title = "Crash_report"
+            let crashedWithoutSession: Bool = model.sessionId.isEmpty || model.sessionId == " "
+            let crash = Crash(
+                id: model.id,
+                timestamp: model.timestamp,
+                title: title,
+                appVersion: model.appVersion,
+                buildVersion: model.buildVersion,
+                osVersion: model.osVersion,
+                deviceType: model.deviceType,
+                sessionId: model.sessionId,
+                network: model.network,
+                carrier: model.carrier,
+                deviceId: model.deviceId,
+                eventIdentifier: model.eventIdentifier,
+                crashedWithoutSession: crashedWithoutSession,
+                report: report
             )
             
             // Send report to backend

--- a/Trace/Library/CrashReportingSwift/CrashController.swift
+++ b/Trace/Library/CrashReportingSwift/CrashController.swift
@@ -17,6 +17,13 @@ import TraceInternal
 @objc(BRCrashController)
 public final class CrashController: NSObject {
     
+    // MARK: - Enum
+    
+    enum Keys: String {
+        case traceId = "Trace Id"
+        case resource = "Resource"
+    }
+    
     // MARK: - Property
     
     private let scheduler: Scheduler

--- a/Trace/Library/Database/Persistent.swift
+++ b/Trace/Library/Database/Persistent.swift
@@ -93,6 +93,8 @@ final internal class Persistent: NSPersistentContainer {
                 Logger.error(.database, "Failed to create directory with error: \(error.localizedDescription)")
             }
         }
+        
+        Logger.debug(.database, url.absoluteString)
             
         return url
     }

--- a/Trace/Metric/Resource.swift
+++ b/Trace/Metric/Resource.swift
@@ -16,6 +16,7 @@ struct Resource: Codable {
     private enum CodingKeys: CodingKey {
         enum Labels: String, CodingKey {
             case appVersion = "app.version"
+            case buildVersion = "app.build"
             case uuid = "device.id"
             case osVersion = "os.version"
             case deviceType = "device.type"
@@ -34,8 +35,9 @@ struct Resource: Codable {
     // MARK: - Property
     
     let type: String = "mobile"
-    let platform: String = "iOS"
+    let platform: String
     let appVersion: String
+    let buildVersion: String
     let uuid: String
     let osVersion: String
     let deviceType: String
@@ -50,12 +52,15 @@ struct Resource: Codable {
     
     init(from details: OrderedDictionary<String, String>) {
         appVersion = details[DeviceFormatter.Keys.Application.version.rawValue] ?? ""
+        buildVersion = details[DeviceFormatter.Keys.Application.build.rawValue] ?? ""
         uuid = details[DeviceFormatter.Keys.uuid.rawValue] ?? ""
         osVersion = details[DeviceFormatter.Keys.systemVersion.rawValue] ?? ""
         deviceType = details[DeviceFormatter.Keys.model.rawValue] ?? ""
         carrier = details[DeviceFormatter.Keys.Carrier.name.rawValue] ?? ""
         jailbroken = details[DeviceFormatter.Keys.jailbroken.rawValue] ?? ""
         sdkVersion = details[DeviceFormatter.Keys.SDK.version.rawValue] ?? ""
+        platform = details[DeviceFormatter.Keys.platform.rawValue] ?? ""
+        
         network = ""
         session = ""
     }
@@ -68,6 +73,7 @@ struct Resource: Codable {
         )
         
         appVersion = try nestedContainer.decode(String.self, forKey: .appVersion)
+        buildVersion = try nestedContainer.decode(String.self, forKey: .buildVersion)
         uuid = try nestedContainer.decode(String.self, forKey: .uuid)
         osVersion = try nestedContainer.decode(String.self, forKey: .osVersion)
         deviceType = try nestedContainer.decode(String.self, forKey: .deviceType)
@@ -76,6 +82,7 @@ struct Resource: Codable {
         session = try nestedContainer.decode(String.self, forKey: .sessionId)
         jailbroken = try nestedContainer.decode(String.self, forKey: .jailbroken)
         sdkVersion = try nestedContainer.decode(String.self, forKey: .sdkVersion)
+        platform = try nestedContainer.decode(String.self, forKey: .platform)
     }
     
     // MARK: - Encode
@@ -86,6 +93,7 @@ struct Resource: Codable {
         
         try container.encode(type, forKey: .type)
         try nestedContainer.encode(appVersion, forKey: .appVersion)
+        try nestedContainer.encode(buildVersion, forKey: .buildVersion)
         try nestedContainer.encode(uuid, forKey: .uuid)
         try nestedContainer.encode(osVersion, forKey: .osVersion)
         try nestedContainer.encode(deviceType, forKey: .deviceType)
@@ -105,6 +113,7 @@ extension Resource: Hashable {
     static func == (lhs: Resource, rhs: Resource) -> Bool {
         return
             lhs.appVersion == rhs.appVersion &&
+            lhs.buildVersion == rhs.buildVersion &&
             lhs.osVersion == rhs.osVersion &&
             lhs.uuid == rhs.uuid &&
             lhs.session == rhs.session

--- a/Trace/TraceModel/Tracer.swift
+++ b/Trace/TraceModel/Tracer.swift
@@ -52,7 +52,7 @@ final class Tracer {
         }
         
         traces.append(trace)
-        crash.userInfo["Trace Id"] = trace.traceId
+        crash.userInfo[CrashController.Keys.traceId.rawValue] = trace.traceId
         
         Logger.debug(.traceModel, trace)
         

--- a/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -417,7 +417,7 @@ static NSDictionary* g_registerOrders;
     NSString* cpuArch = [system objectForKey:@KSCrashField_CPUArch];
     NSString* cpuArchType = [self CPUType:cpuArch];
 
-    [str appendFormat:@"Incident Identifier: %@\n", reportID];
+    [str appendFormat:@"SDK Event Identifier: %@\n", reportID];
     [str appendFormat:@"CrashReporter Key:   %@\n", [system objectForKey:@KSCrashField_DeviceAppHash]];
     [str appendFormat:@"Hardware Model:      %@\n", [system objectForKey:@KSCrashField_Machine]];
     [str appendFormat:@"Process:         %@ [%@]\n",
@@ -428,6 +428,10 @@ static NSDictionary* g_registerOrders;
     [str appendFormat:@"Version:         %@ (%@)\n",
      [system objectForKey:@KSCrashField_BundleVersion],
      [system objectForKey:@KSCrashField_BundleShortVersion]];
+    [str appendFormat:@"App Version:         %@\n",
+     [system objectForKey:@KSCrashField_BundleShortVersion]];
+    [str appendFormat:@"Build Version:         %@\n",
+     [system objectForKey:@KSCrashField_BundleVersion]];
     [str appendFormat:@"Code Type:       %@\n", cpuArchType];
     [str appendFormat:@"Parent Process:  ? [%@]\n",
      [system objectForKey:@KSCrashField_ParentProcessID]];

--- a/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -115,8 +115,10 @@ static NSDictionary* g_registerOrders;
 + (void) initialize
 {
     g_dateFormatter = [[NSDateFormatter alloc] init];
+    [g_dateFormatter setCalendar: [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierISO8601]];
     [g_dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-    [g_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssXXX"];
+    [g_dateFormatter setTimeZone: [NSTimeZone timeZoneForSecondsFromGMT: 0]];
+    [g_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssxxx"];
 
     g_rfc3339DateFormatter = [[NSDateFormatter alloc] init];
     [g_rfc3339DateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
@@ -334,6 +336,7 @@ static NSDictionary* g_registerOrders;
     {
         return nil;
     }
+    
     return [g_dateFormatter stringFromDate:date];
 }
 

--- a/iOSDemo/Application/AppDelegate.swift
+++ b/iOSDemo/Application/AppDelegate.swift
@@ -7,9 +7,6 @@
 //
 
 import UIKit
-
-// See more here: https://bugs.swift.org/browse/SR-3801
-// and here: https://github.com/apple/swift/commit/08af6f0c0933dc70cb868633e2e017b63c12eba1
 import Trace
 
 @UIApplicationMain

--- a/iOSDemo/View Controller/Main/ViewController.swift
+++ b/iOSDemo/View Controller/Main/ViewController.swift
@@ -71,6 +71,10 @@ final class ViewController: UITableViewController {
     
     private func setup() {
         view.addSubview(customView)
+        
+        let path = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0]
+        
+        print("DEMO - Document directory: \(path)")
     }
     
     // MARK: - Navigation


### PR DESCRIPTION
## Proposed changes:
- Add Resource fields to form field HTTP header
- `Incident Identifier` renamed to `SDK Event Identifier`
- `platform` hardcoded value removed for runtime check
- Enum used for string keys
- New RegX scan for resource fields with formatting fixer
- Crash date formatted updated to remove spaces 
- Added Cache-Control to curl request

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
