### PR TITLE
Use custom date formatter for crash reports

### DIFF
--- a/CrashReportingTests/BRKSCrashReportFilterAppleFmtTests.m
+++ b/CrashReportingTests/BRKSCrashReportFilterAppleFmtTests.m
@@ -1,0 +1,52 @@
+//
+//  BRKSCrashReportFilterAppleFmtTests.m
+//  CrashReportingTests
+//
+//  Created by Shams Ahmed on 25/01/2021.
+//  Copyright © 2021 Bitrise. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "KSCrashReportFilterAppleFmt.h"
+
+@interface BRKSCrashReportFilterAppleFmtTests : XCTestCase
+
+@end
+
+@implementation BRKSCrashReportFilterAppleFmtTests
+
+- (void)setUp {
+
+}
+
+- (void)tearDown {
+
+}
+
+- (void)testClass {
+    KSCrashReportFilterAppleFmt *report = [[KSCrashReportFilterAppleFmt alloc] init];
+    
+    XCTAssertNotNil(report);
+}
+
+- (void)testDateFormat1970 {
+    KSCrashReportFilterAppleFmt *report = [[KSCrashReportFilterAppleFmt alloc] init];
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:0];
+    NSString *string = [report stringFromDate: date];
+    
+    XCTAssertNotNil(string);
+    XCTAssertFalse([string containsString:@"T"]);
+    XCTAssertTrue([string isEqualToString:@"1970-01-01 00:00:00+00:00"]);
+}
+
+- (void)testDateFormatCustom {
+    KSCrashReportFilterAppleFmt *report = [[KSCrashReportFilterAppleFmt alloc] init];
+    NSDate *date = [NSDate date];
+    NSString *string = [report stringFromDate: date];
+    
+    XCTAssertNotNil(string);
+    XCTAssertFalse([string containsString:@"T"]);
+    XCTAssertFalse([string containsString:@" "]);
+}
+
+@end

--- a/Tests/Supporting Files/noTraceId.crash
+++ b/Tests/Supporting Files/noTraceId.crash
@@ -10,7 +10,7 @@ Build Version:         1
 Code Type:       X86
 Parent Process:  ? [90972]
 
-Date/Time:       2020-03-11 16:35:29.357 +0000
+Date/Time:       2020-03-11 16:35:29.357+00:00
 OS Version:      iOS 13.3 (19C57)
 Report Version:  104
 Resource:

--- a/Tests/Supporting Files/outOfBound.crash
+++ b/Tests/Supporting Files/outOfBound.crash
@@ -10,7 +10,7 @@ Build Version:         1
 Code Type:       X86
 Parent Process:  ? [90972]
 
-Date/Time:       2020-03-11 16:35:29.357 +0000
+Date/Time:       2020-03-11 16:35:29.357+00:00
 OS Version:      iOS 13.3 (19C57)
 Report Version:  104
 Trace Id: 11XiSA5imvey3LCM

--- a/Tests/Supporting Files/traceIdEmpty.crash
+++ b/Tests/Supporting Files/traceIdEmpty.crash
@@ -10,7 +10,7 @@ Build Version:         1
 Code Type:       X86
 Parent Process:  ? [90972]
 
-Date/Time:       2020-03-11 16:35:29.357 +0000
+Date/Time:       2020-03-11 16:35:29.357+00:00
 OS Version:      iOS 13.3 (19C57)
 Report Version:  104
 Trace Id: 

--- a/Trace.xcodeproj/project.pbxproj
+++ b/Trace.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		10D1E47922E8A96F007BD5E1 /* Entities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D1E47822E8A96F007BD5E1 /* Entities.swift */; };
 		10D1E47C22E9AA83007BD5E1 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D1E47B22E9AA83007BD5E1 /* Scheduler.swift */; };
 		10D1E48022EB0088007BD5E1 /* Repeater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D1E47F22EB0088007BD5E1 /* Repeater.swift */; };
+		10D4C91625BEF02600BD9601 /* BRKSCrashReportFilterAppleFmtTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 10D4C91525BEF02600BD9601 /* BRKSCrashReportFilterAppleFmtTests.m */; };
 		10D7E8FA2344FE580032FBA3 /* FPSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D7E8F92344FE580032FBA3 /* FPSTests.swift */; };
 		10D7E8FC23450E730032FBA3 /* JSONEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D7E8FB23450E730032FBA3 /* JSONEncodableTests.swift */; };
 		10DCA093230420C800F0281E /* Encodable+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DCA092230420C800F0281E /* Encodable+Helper.swift */; };
@@ -1270,6 +1271,7 @@
 		10D1E47822E8A96F007BD5E1 /* Entities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entities.swift; sourceTree = "<group>"; };
 		10D1E47B22E9AA83007BD5E1 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
 		10D1E47F22EB0088007BD5E1 /* Repeater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repeater.swift; sourceTree = "<group>"; };
+		10D4C91525BEF02600BD9601 /* BRKSCrashReportFilterAppleFmtTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BRKSCrashReportFilterAppleFmtTests.m; sourceTree = "<group>"; };
 		10D7E8F92344FE580032FBA3 /* FPSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FPSTests.swift; path = Tests/FPSTests.swift; sourceTree = SOURCE_ROOT; };
 		10D7E8FB23450E730032FBA3 /* JSONEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JSONEncodableTests.swift; path = Tests/JSONEncodableTests.swift; sourceTree = SOURCE_ROOT; };
 		10DCA092230420C800F0281E /* Encodable+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Helper.swift"; sourceTree = "<group>"; };
@@ -2494,6 +2496,7 @@
 				108CDEF723FC55DE00153BEB /* TestThread.m */,
 				108CDF0023FC55DE00153BEB /* XCTestCase+KSCrash.h */,
 				108CDEF823FC55DE00153BEB /* XCTestCase+KSCrash.m */,
+				10D4C91525BEF02600BD9601 /* BRKSCrashReportFilterAppleFmtTests.m */,
 				1053AAB223FCB8A900F90393 /* Mocks */,
 				108CDEDF23FC547700153BEB /* Supporting files */,
 			);
@@ -4632,6 +4635,7 @@
 				108CDF2223FC55E000153BEB /* KSMemory_Tests.m in Sources */,
 				108CDF1523FC55DF00153BEB /* KSDynamicLinker_Tests.m in Sources */,
 				108CDF1F23FC55E000153BEB /* RFC3339UTFString_Tests.m in Sources */,
+				10D4C91625BEF02600BD9601 /* BRKSCrashReportFilterAppleFmtTests.m in Sources */,
 				108CDF2D23FC55E000153BEB /* KSFileUtils_Tests.m in Sources */,
 				108CDF3123FC55E000153BEB /* KSCrashMonitor_NSException_Tests.m in Sources */,
 				108CDF2023FC55E000153BEB /* TestThread.m in Sources */,

--- a/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.h
+++ b/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.h
@@ -112,6 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id) initWithReportStyle:(KSAppleReportStyle) reportStyle;
 
 - (NSString*)headerStringForSystemInfo:(NSDictionary*)system reportID:(NSString*)reportID crashTime:(NSDate*)crashTime;
+- (NSString*) stringFromDate:(NSDate*)date;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/TraceInternal/CrashReporting/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -118,7 +118,7 @@ static NSDictionary* g_registerOrders;
     [g_dateFormatter setCalendar: [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierISO8601]];
     [g_dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [g_dateFormatter setTimeZone: [NSTimeZone timeZoneForSecondsFromGMT: 0]];
-    [g_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssxxx"];
+    [g_dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ssxxx"];
 
     g_rfc3339DateFormatter = [[NSDateFormatter alloc] init];
     [g_rfc3339DateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];


### PR DESCRIPTION
## Proposed changes:
- Use custom date formatter for crash reports

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
