### PR TITLE
Call crash install at launch

### DIFF
--- a/Tests/CrashControllerTests.swift
+++ b/Tests/CrashControllerTests.swift
@@ -30,7 +30,7 @@ final class CrashControllerTests: XCTestCase {
     func testAddingUserInfo() {
         let crash = newCrash
         
-        XCTAssertEqual(crash.userInfo.count, 0)
+        XCTAssertEqual(crash.userInfo.count, 1)
         
         crash.userInfo = ["test": "one"]
         
@@ -41,7 +41,7 @@ final class CrashControllerTests: XCTestCase {
     func testRemovingUserInfo() {
         let crash = newCrash
         
-        XCTAssertEqual(crash.userInfo.count, 0)
+        XCTAssertEqual(crash.userInfo.count, 1)
         
         crash.userInfo = ["test": "two"]
         crash.userInfo.removeAll()
@@ -53,11 +53,11 @@ final class CrashControllerTests: XCTestCase {
     func testUpdatingUserInfo() {
         let crash = newCrash
         
-        XCTAssertEqual(crash.userInfo.count, 0)
+        XCTAssertEqual(crash.userInfo.count, 1)
         
         crash.userInfo["test"] = "one"
         
-        XCTAssertEqual(crash.userInfo.count, 1)
+        XCTAssertEqual(crash.userInfo.count, 2)
         
         crash.userInfo["test"] = "two"
         

--- a/Trace/Hardware/Session.swift
+++ b/Trace/Hardware/Session.swift
@@ -96,7 +96,9 @@ final class Session {
             connectivity: connectivity
         )
         
-        if let interface = connectivity.interface.interface {
+        if let interface = connectivity.interface.interface,
+           !interface.isEmpty,
+           resource.network != interface {
             resource.network = interface
         }
         

--- a/Trace/Library/CrashReportingSwift/CrashController.swift
+++ b/Trace/Library/CrashReportingSwift/CrashController.swift
@@ -57,16 +57,15 @@ public final class CrashController: NSObject {
     // MARK: - Setup
     
     private func setup(with resource: Resource) {
+        installation.install()
+        
         if let dictionary = try? resource.dictionary() {
             userInfo[Keys.resource.rawValue] = dictionary
         }
     }
     
-    /// Call setup before accessing crash installation
-    /// Called afterward SDK has finished starting up
+    /// Called after SDK has finished starting up
     internal func postSetup() {
-        installation.install()
-        
         scheduleNewReports()
     }
     

--- a/Trace/Trace.swift
+++ b/Trace/Trace.swift
@@ -107,17 +107,17 @@ final public class Trace: NSObject {
         setupConfiguration()
         
         if Trace.configuration.log == .debug {
-            Logger.default(.application, "Verbose logs has been enabled while in Beta. Configure using swift: `Trace.configuration.log` or ObjC: `BRTrace.configuration.log`")
+            Logger.default(.application, "Verbose logs has been enabled while in Beta. Configure in Swift: `Trace.configuration.log` ObjC: `BRTrace.configuration.log`")
         }
+        
+        setupSwizzle()
+        setupStartupTrace(with: initializationTime)
         
         #if DEBUG || Debug || debug
         Logger.debug(.crash, "Disabled since app is running in Debug mode")
         #else
         setupCrashReporting()
         #endif
-        
-        setupSwizzle()
-        setupStartupTrace(with: initializationTime)
     }
     
     private func setupConfiguration() {


### PR DESCRIPTION
## Proposed changes:
- Avoid refreshing Resource model on duplicate changes
- Call `crash.install()` at launch

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
