### PR TITLE
Changed app memory metric from double to int

### DIFF
--- a/Tests/HardwareFormatterTests.swift
+++ b/Tests/HardwareFormatterTests.swift
@@ -92,9 +92,8 @@ final class HardwareFormatterTests: XCTestCase {
             
             return HardwareFormatter(cpu: cpu, memory: memory, connectivity: connectivity)
         }()
-        
-        let metric = formatter.metrics.metrics.first!
-        
-        assertSnapshot(matching: metric.descriptor, as: .json)
+        formatter.metrics.metrics.forEach {
+            assertSnapshot(matching: $0.descriptor, as: .json)
+        }
     }
 }

--- a/Tests/TaskMetricsFormatterTests.swift
+++ b/Tests/TaskMetricsFormatterTests.swift
@@ -143,8 +143,8 @@ final class TaskMetricsFormatterTests: XCTestCase {
     
     func testDescriptor_snapshot() {
         let formatter = TaskMetricsFormatter(mock)
-        let metric = formatter.metrics.metrics.first!
-        
-        assertSnapshot(matching: metric.descriptor, as: .json)
+        formatter.metrics.metrics.forEach {
+            assertSnapshot(matching: $0.descriptor, as: .json)
+        }
     }
 }

--- a/Tests/URLSessionTaskFormatterTests.swift
+++ b/Tests/URLSessionTaskFormatterTests.swift
@@ -175,8 +175,9 @@ final class URLSessionTaskFormatterTests: XCTestCase {
         )
         let task = session.downloadTask(with: url) { _, _, _ in }
         let formatter = URLSessionTaskFormatter(task)
-        let metric = formatter.metrics.metrics.first!
         
-        assertSnapshot(matching: metric.descriptor, as: .json)
+        formatter.metrics.metrics.forEach {
+            assertSnapshot(matching: $0.descriptor, as: .json)
+        }
     }
 }

--- a/Tests/__Snapshots__/HardwareFormatterTests/testDescriptor_snapshot.2.json
+++ b/Tests/__Snapshots__/HardwareFormatterTests/testDescriptor_snapshot.2.json
@@ -1,0 +1,9 @@
+{
+  "description" : "Application CPU Usage",
+  "label_keys" : [
+
+  ],
+  "name" : "process.cpu.pct",
+  "type" : 2,
+  "unit" : "percent"
+}

--- a/Tests/__Snapshots__/HardwareFormatterTests/testDescriptor_snapshot.3.json
+++ b/Tests/__Snapshots__/HardwareFormatterTests/testDescriptor_snapshot.3.json
@@ -1,0 +1,12 @@
+{
+  "description" : "App Memory Usage",
+  "label_keys" : [
+    {
+      "description" : "",
+      "key" : "memory.state"
+    }
+  ],
+  "name" : "app.memory.bytes",
+  "type" : 1,
+  "unit" : "bytes"
+}

--- a/Tests/__Snapshots__/TaskMetricsFormatterTests/testDescriptor_snapshot.2.json
+++ b/Tests/__Snapshots__/TaskMetricsFormatterTests/testDescriptor_snapshot.2.json
@@ -1,0 +1,20 @@
+{
+  "description" : "Network response size in bytes",
+  "label_keys" : [
+    {
+      "description" : "",
+      "key" : "http.method"
+    },
+    {
+      "description" : "",
+      "key" : "http.status_code"
+    },
+    {
+      "description" : "",
+      "key" : "http.url"
+    }
+  ],
+  "name" : "app.response.size.bytes",
+  "type" : 1,
+  "unit" : "bytes"
+}

--- a/Tests/__Snapshots__/URLSessionTaskFormatterTests/testDescriptor_snapshot.2.json
+++ b/Tests/__Snapshots__/URLSessionTaskFormatterTests/testDescriptor_snapshot.2.json
@@ -1,0 +1,16 @@
+{
+  "description" : "Network response size in bytes",
+  "label_keys" : [
+    {
+      "description" : "",
+      "key" : "http.url"
+    },
+    {
+      "description" : "",
+      "key" : "http.method"
+    }
+  ],
+  "name" : "app.response.size.bytes",
+  "type" : 1,
+  "unit" : "bytes"
+}

--- a/Trace.xcworkspace/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Trace.xcworkspace/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -87,22 +87,6 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "7D559D18-9CC1-4461-B788-DCBC2320CE87"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Trace/Helper/Swift/TimestampValidator.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "74"
-            endingLineNumber = "74"
-            landmarkName = "isGreaterThanOrEqual(_:)"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
             uuid = "B99034E0-C0D4-4C93-B770-887F181DC73A"
             shouldBeEnabled = "No"
             ignoreCount = "0"

--- a/Trace/Hardware/HardwareFormatter.swift
+++ b/Trace/Hardware/HardwareFormatter.swift
@@ -115,7 +115,7 @@ extension HardwareFormatter: Metricable {
             name: .appMemoryBytes,
             description: "App Memory Usage",
             unit: .bytes,
-            type: .double,
+            type: .int64,
             keys: keys
         )
         let metric = Metric(descriptor: descriptor, timeseries: timeseries)


### PR DESCRIPTION
## Proposed changes:
- Changed app memory metric from `double` to `int`
- Added new snapshot tests
- Fixed some tests and removed shared breakpoints that wasn't useful for debugging metrics

### Pre-requisites:
- [x] Reviewed code before asking reviewer <em>(Look at *Files Changed* below instead of Xcode)</em>.
- [x] Reviewed code format follows the style guide where possible.
- [x] Added tests where possible <em>(*compulsory for business logic and new classes)</em>.
